### PR TITLE
Add php_info default metrics

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -37,12 +37,21 @@ class CollectorRegistry
     private $histograms = [];
 
     /**
+     * @var Gauge[]
+     */
+    private $defaultGauges = [];
+
+    /**
      * CollectorRegistry constructor.
      * @param Adapter $redisAdapter
+     * @param bool $registerDefaultMetrics
      */
-    public function __construct(Adapter $redisAdapter)
+    public function __construct(Adapter $redisAdapter, bool $registerDefaultMetrics = true)
     {
         $this->storageAdapter = $redisAdapter;
+        if ($registerDefaultMetrics) {
+            $this->registerDefaultMetrics();
+        }
     }
 
     /**
@@ -246,5 +255,12 @@ class CollectorRegistry
     private static function metricIdentifier($namespace, $name): string
     {
         return $namespace . ":" . $name;
+    }
+
+    private function registerDefaultMetrics(): void
+    {
+        $this->defaultGauges = ['php_info_gauge' => null];
+        $this->defaultGauges['php_info_gauge'] = $this->getOrRegisterGauge("", "php_info", "Information about the PHP environment.", ["version"]);
+        $this->defaultGauges['php_info_gauge']->set(1, [phpversion()]);
     }
 }

--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -19,7 +19,6 @@ class RenderTextFormat
         });
 
         $lines = [];
-
         foreach ($metrics as $metric) {
             $lines[] = "# HELP " . $metric->getName() . " {$metric->getHelp()}";
             $lines[] = "# TYPE " . $metric->getName() . " {$metric->getType()}";

--- a/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
+++ b/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
@@ -32,6 +32,45 @@ abstract class AbstractCollectorRegistryTest extends TestCase
     /**
      * @test
      */
+    public function itShouldHaveDefaultMetrics()
+    {
+        $registry = new CollectorRegistry($this->adapter);
+        $expected = <<<EOF
+# HELP php_info Information about the PHP environment.
+# TYPE php_info gauge
+php_info{version="%s"} 1
+
+EOF;
+        $this->assertThat(
+            $this->renderer->render($registry->getMetricFamilySamples()),
+            $this->stringContains(
+                sprintf($expected, phpversion())
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotHaveDefaultMetricsWhenTheyAreDisabled()
+    {
+        $registry = new CollectorRegistry($this->adapter, false);
+        $expected = <<<EOF
+# HELP php_info Information about the PHP environment.
+# TYPE php_info gauge
+php_info{version="%s"} 1
+
+EOF;
+        $this->assertStringNotContainsString(
+            sprintf($expected, phpversion()),
+            $this->renderer->render($registry->getMetricFamilySamples())
+        );
+    }
+
+
+    /**
+     * @test
+     */
     public function itShouldSaveGauges()
     {
         $registry = new CollectorRegistry($this->adapter);
@@ -46,7 +85,7 @@ abstract class AbstractCollectorRegistryTest extends TestCase
         $registry = new CollectorRegistry($this->adapter);
         $this->assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->equalTo(
+            $this->stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric gauge
@@ -74,7 +113,7 @@ EOF
         $registry = new CollectorRegistry($this->adapter);
         $this->assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->equalTo(
+            $this->stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric counter
@@ -108,7 +147,7 @@ EOF
         $registry = new CollectorRegistry($this->adapter);
         $this->assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->equalTo(
+            $this->stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric histogram
@@ -153,7 +192,7 @@ EOF
         $registry = new CollectorRegistry($this->adapter);
         $this->assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->equalTo(
+            $this->stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric histogram
@@ -188,12 +227,11 @@ EOF
         $registry = new CollectorRegistry($this->adapter);
         $registry
             ->registerCounter('', 'some_quick_counter', 'just a quick measurement')
-            ->inc()
-        ;
+            ->inc();
 
         $this->assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->equalTo(
+            $this->stringContains(
                 <<<EOF
 # HELP some_quick_counter just a quick measurement
 # TYPE some_quick_counter counter


### PR DESCRIPTION
This MR adds a new metric that is exposed (default) on every exporter that is using this client. This follows the other (official) client libraries, like go (https://github.com/prometheus/client_golang/blob/6007b2b5cae01203111de55f753e76d8dac1f529/prometheus/go_collector.go#L79) `go_info` or python (https://github.com/prometheus/client_python/blob/master/prometheus_client/platform_collector.py#L10) `python_info`. 

Futurewise there will be more "default" metrics.

If you don't want to expose this metric, you can easily disable them by creating the registry with disabled default metrics:
```
$registry = new CollectorRegistry($this->adapter, false);
```
Signed-off-by: Lukas Kämmerling <kontakt@lukas-kaemmerling.de>