### PR TITLE
Extract interfaces for Registry and Renderer

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -9,7 +9,7 @@ use Prometheus\Exception\MetricsRegistrationException;
 use Prometheus\Storage\Adapter;
 use Prometheus\Storage\Redis;
 
-class CollectorRegistry
+class CollectorRegistry implements RegistryInterface
 {
     /**
      * @var CollectorRegistry

--- a/src/Prometheus/RegistryInterface.php
+++ b/src/Prometheus/RegistryInterface.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Prometheus;
+
+use Prometheus\Exception\MetricNotFoundException;
+use Prometheus\Exception\MetricsRegistrationException;
+
+interface RegistryInterface
+{
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function getMetricFamilySamples(): array;
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Gauge
+     * @throws MetricsRegistrationException
+     */
+    public function registerGauge($namespace, $name, $help, $labels = []): Gauge;
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return Gauge
+     * @throws MetricNotFoundException
+     */
+    public function getGauge($namespace, $name): Gauge;
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Gauge
+     * @throws MetricsRegistrationException
+     */
+    public function getOrRegisterGauge($namespace, $name, $help, $labels = []): Gauge;
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Counter
+     * @throws MetricsRegistrationException
+     */
+    public function registerCounter($namespace, $name, $help, $labels = []): Counter;
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return Counter
+     * @throws MetricNotFoundException
+     */
+    public function getCounter($namespace, $name): Counter;
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Counter
+     * @throws MetricsRegistrationException
+     */
+    public function getOrRegisterCounter($namespace, $name, $help, $labels = []): Counter;
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     * @param array  $buckets e.g. [100, 200, 300]
+     *
+     * @return Histogram
+     * @throws MetricsRegistrationException
+     */
+    public function registerHistogram($namespace, $name, $help, $labels = [], $buckets = null): Histogram;
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return Histogram
+     * @throws MetricNotFoundException
+     */
+    public function getHistogram($namespace, $name): Histogram;
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     * @param array  $buckets e.g. [100, 200, 300]
+     *
+     * @return Histogram
+     * @throws MetricsRegistrationException
+     */
+    public function getOrRegisterHistogram($namespace, $name, $help, $labels = [], $buckets = null): Histogram;
+}

--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Prometheus;
 
-class RenderTextFormat
+class RenderTextFormat implements RendererInterface
 {
     const MIME_TYPE = 'text/plain; version=0.0.4';
 

--- a/src/Prometheus/RendererInterface.php
+++ b/src/Prometheus/RendererInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Prometheus;
+
+interface RendererInterface
+{
+    /**
+     * @param MetricFamilySamples[] $metrics
+     *
+     * @return string
+     */
+    public function render(array $metrics): string;
+}


### PR DESCRIPTION
The registry and the renderer are classes that are usually injected by
users into their own code, having interfaces for them allow users to
mock based on the API and not on the concrete implementation which avoids
a common code smell. This also allows better custom implementations if
users so desire.