### PR TITLE
Improve Type Hinting

### DIFF
--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -1,0 +1,39 @@
+name: BlackBox Tests
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+
+    name: Run BlackBox Tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-blackbox
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-suggest
+
+      - name: Compose Blackbox environment
+        run: docker-compose up -d
+      - name: Run Blackbox with APC
+        run: docker-compose run phpunit env ADAPTER=apc vendor/bin/phpunit tests/Test/
+      - name: Run Blackbox with Redis
+        run: docker-compose run phpunit env ADAPTER=redis vendor/bin/phpunit tests/Test/
+
+
+

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,33 @@
+name: Code Checks
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+
+    name: Code Checks
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-code-checks
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-suggest
+      - name: Run PHP Code Sniffer
+        run: ./vendor/bin/phpcs
+      - name: Run PHPStan
+        run: php vendor/bin/phpstan analyse --autoload-file tests/bootstrap.php

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,5 @@ jobs:
         uses: supercharge/redis-github-action@1.1.0
         with:
           redis-version: ${{ matrix.redis-version }}
-      - name: Run PHP Code Sniffer
-        run: ./vendor/bin/phpcs
-      - name: Run phpstan
-        run: php vendor/bin/phpstan analyse src tests --level 1 --autoload-file tests/bootstrap.php
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,10 @@
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "phpstan/phpstan": "^0.12.48",
+        "phpstan/extension-installer": "^1.0",
+        "phpstan/phpstan": "^0.12.50",
+        "phpstan/phpstan-phpunit": "^0.12.16",
+        "phpstan/phpstan-strict-rules": "^0.12.5",
         "phpunit/phpunit": "^8.4",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,7 +1,7 @@
-FROM php:5.6-fpm
+FROM php:7.4-fpm
 
-RUN pecl install redis-2.2.8 && docker-php-ext-enable redis
-RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
+RUN pecl install redis-5.3.1 && docker-php-ext-enable redis
+RUN pecl install apcu-5.1.19 && docker-php-ext-enable apcu
 
 COPY www.conf /usr/local/etc/php-fpm.d/
 COPY docker-php-ext-apcu-cli.ini /usr/local/etc/php/conf.d/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        -
+            # REDIS stuff only runs with it available
+            '#Constant REDIS_HOST not found\.#'

--- a/src/Prometheus/Collector.php
+++ b/src/Prometheus/Collector.php
@@ -27,28 +27,28 @@ abstract class Collector
     protected $help;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $labels;
 
     /**
      * @param Adapter $storageAdapter
-     * @param string $namespace
-     * @param string $name
-     * @param string $help
-     * @param array $labels
+     * @param string  $namespace
+     * @param string  $name
+     * @param string  $help
+     * @param string[]   $labels
      */
-    public function __construct(Adapter $storageAdapter, $namespace, $name, $help, $labels = [])
+    public function __construct(Adapter $storageAdapter, string $namespace, string $name, string $help, array $labels = [])
     {
         $this->storageAdapter = $storageAdapter;
-        $metricName = ($namespace ? $namespace . '_' : '') . $name;
-        if (!preg_match(self::RE_METRIC_LABEL_NAME, $metricName)) {
+        $metricName = ($namespace !== '' ? $namespace . '_' : '') . $name;
+        if (preg_match(self::RE_METRIC_LABEL_NAME, $metricName) !== 1) {
             throw new InvalidArgumentException("Invalid metric name: '" . $metricName . "'");
         }
         $this->name = $metricName;
         $this->help = $help;
         foreach ($labels as $label) {
-            if (!preg_match(self::RE_METRIC_LABEL_NAME, $label)) {
+            if (preg_match(self::RE_METRIC_LABEL_NAME, $label) !== 1) {
                 throw new InvalidArgumentException("Invalid label name: '" . $label . "'");
             }
         }
@@ -58,7 +58,7 @@ abstract class Collector
     /**
      * @return string
      */
-    abstract public function getType();
+    abstract public function getType(): string;
 
     /**
      * @return string
@@ -69,7 +69,7 @@ abstract class Collector
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getLabelNames(): array
     {
@@ -93,11 +93,11 @@ abstract class Collector
     }
 
     /**
-     * @param $labels
+     * @param string[] $labels
      */
-    protected function assertLabelsAreDefinedCorrectly($labels): void
+    protected function assertLabelsAreDefinedCorrectly(array $labels): void
     {
-        if (count($labels) != count($this->labels)) {
+        if (count($labels) !== count($this->labels)) {
             throw new InvalidArgumentException(sprintf('Labels are not defined correctly: %s', print_r($labels, true)));
         }
     }

--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -43,8 +43,9 @@ class CollectorRegistry implements RegistryInterface
 
     /**
      * CollectorRegistry constructor.
+     *
      * @param Adapter $storageAdapter
-     * @param bool $registerDefaultMetrics
+     * @param bool    $registerDefaultMetrics
      */
     public function __construct(Adapter $storageAdapter, bool $registerDefaultMetrics = true)
     {
@@ -59,10 +60,7 @@ class CollectorRegistry implements RegistryInterface
      */
     public static function getDefault(): CollectorRegistry
     {
-        if (!self::$defaultRegistry) {
-            return self::$defaultRegistry = new self(new Redis());
-        }
-        return self::$defaultRegistry;
+        return self::$defaultRegistry ?? (self::$defaultRegistry = new self(new Redis()));
     }
 
     /**
@@ -74,14 +72,15 @@ class CollectorRegistry implements RegistryInterface
     }
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. duration_seconds
-     * @param string $help e.g. The duration something took in seconds.
-     * @param array $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. duration_seconds
+     * @param string   $help e.g. The duration something took in seconds.
+     * @param string[] $labels e.g. ['controller', 'action']
+     *
      * @return Gauge
      * @throws MetricsRegistrationException
      */
-    public function registerGauge($namespace, $name, $help, $labels = []): Gauge
+    public function registerGauge(string $namespace, string $name, string $help, $labels = []): Gauge
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
         if (isset($this->gauges[$metricIdentifier])) {
@@ -100,27 +99,29 @@ class CollectorRegistry implements RegistryInterface
     /**
      * @param string $namespace
      * @param string $name
+     *
      * @return Gauge
      * @throws MetricNotFoundException
      */
-    public function getGauge($namespace, $name): Gauge
+    public function getGauge(string $namespace, string $name): Gauge
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
-        if (!isset($this->gauges[$metricIdentifier])) {
+        if (! isset($this->gauges[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
         return $this->gauges[$metricIdentifier];
     }
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. duration_seconds
-     * @param string $help e.g. The duration something took in seconds.
-     * @param array $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. duration_seconds
+     * @param string   $help e.g. The duration something took in seconds.
+     * @param string[] $labels e.g. ['controller', 'action']
+     *
      * @return Gauge
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterGauge($namespace, $name, $help, $labels = []): Gauge
+    public function getOrRegisterGauge(string $namespace, string $name, string $help, $labels = []): Gauge
     {
         try {
             $gauge = $this->getGauge($namespace, $name);
@@ -131,14 +132,15 @@ class CollectorRegistry implements RegistryInterface
     }
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. requests
-     * @param string $help e.g. The number of requests made.
-     * @param array $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. requests
+     * @param string   $help e.g. The number of requests made.
+     * @param string[] $labels e.g. ['controller', 'action']
+     *
      * @return Counter
      * @throws MetricsRegistrationException
      */
-    public function registerCounter($namespace, $name, $help, $labels = []): Counter
+    public function registerCounter(string $namespace, string $name, string $help, $labels = []): Counter
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
         if (isset($this->counters[$metricIdentifier])) {
@@ -157,27 +159,29 @@ class CollectorRegistry implements RegistryInterface
     /**
      * @param string $namespace
      * @param string $name
+     *
      * @return Counter
      * @throws MetricNotFoundException
      */
-    public function getCounter($namespace, $name): Counter
+    public function getCounter(string $namespace, string $name): Counter
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
-        if (!isset($this->counters[$metricIdentifier])) {
+        if (! isset($this->counters[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
         return $this->counters[self::metricIdentifier($namespace, $name)];
     }
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. requests
-     * @param string $help e.g. The number of requests made.
-     * @param array $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. requests
+     * @param string   $help e.g. The number of requests made.
+     * @param string[] $labels e.g. ['controller', 'action']
+     *
      * @return Counter
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterCounter($namespace, $name, $help, $labels = []): Counter
+    public function getOrRegisterCounter(string $namespace, string $name, string $help, $labels = []): Counter
     {
         try {
             $counter = $this->getCounter($namespace, $name);
@@ -188,16 +192,22 @@ class CollectorRegistry implements RegistryInterface
     }
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. duration_seconds
-     * @param string $help e.g. A histogram of the duration in seconds.
-     * @param array $labels e.g. ['controller', 'action']
-     * @param array $buckets e.g. [100, 200, 300]
+     * @param string     $namespace e.g. cms
+     * @param string     $name e.g. duration_seconds
+     * @param string     $help e.g. A histogram of the duration in seconds.
+     * @param string[]   $labels e.g. ['controller', 'action']
+     * @param mixed[]|null $buckets e.g. [100, 200, 300]
+     *
      * @return Histogram
      * @throws MetricsRegistrationException
      */
-    public function registerHistogram($namespace, $name, $help, $labels = [], $buckets = null): Histogram
-    {
+    public function registerHistogram(
+        string $namespace,
+        string $name,
+        string $help,
+        array $labels = [],
+        array $buckets = null
+    ): Histogram {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
         if (isset($this->histograms[$metricIdentifier])) {
             throw new MetricsRegistrationException("Metric already registered");
@@ -216,29 +226,36 @@ class CollectorRegistry implements RegistryInterface
     /**
      * @param string $namespace
      * @param string $name
+     *
      * @return Histogram
      * @throws MetricNotFoundException
      */
-    public function getHistogram($namespace, $name): Histogram
+    public function getHistogram(string $namespace, string $name): Histogram
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
-        if (!isset($this->histograms[$metricIdentifier])) {
+        if (! isset($this->histograms[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
         return $this->histograms[self::metricIdentifier($namespace, $name)];
     }
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. duration_seconds
-     * @param string $help e.g. A histogram of the duration in seconds.
-     * @param array $labels e.g. ['controller', 'action']
-     * @param array $buckets e.g. [100, 200, 300]
+     * @param string     $namespace e.g. cms
+     * @param string     $name e.g. duration_seconds
+     * @param string     $help e.g. A histogram of the duration in seconds.
+     * @param string[]      $labels e.g. ['controller', 'action']
+     * @param mixed[]|null $buckets e.g. [100, 200, 300]
+     *
      * @return Histogram
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterHistogram($namespace, $name, $help, $labels = [], $buckets = null): Histogram
-    {
+    public function getOrRegisterHistogram(
+        string $namespace,
+        string $name,
+        string $help,
+        array $labels = [],
+        array $buckets = null
+    ): Histogram {
         try {
             $histogram = $this->getHistogram($namespace, $name);
         } catch (MetricNotFoundException $e) {
@@ -248,19 +265,24 @@ class CollectorRegistry implements RegistryInterface
     }
 
     /**
-     * @param $namespace
-     * @param $name
+     * @param string $namespace
+     * @param string $name
+     *
      * @return string
      */
-    private static function metricIdentifier($namespace, $name): string
+    private static function metricIdentifier(string $namespace, string $name): string
     {
         return $namespace . ":" . $name;
     }
 
     private function registerDefaultMetrics(): void
     {
-        $this->defaultGauges = ['php_info_gauge' => null];
-        $this->defaultGauges['php_info_gauge'] = $this->getOrRegisterGauge("", "php_info", "Information about the PHP environment.", ["version"]);
-        $this->defaultGauges['php_info_gauge']->set(1, [phpversion()]);
+        $this->defaultGauges['php_info_gauge'] = $this->getOrRegisterGauge(
+            "",
+            "php_info",
+            "Information about the PHP environment.",
+            ["version"]
+        );
+        $this->defaultGauges['php_info_gauge']->set(1, [PHP_VERSION]);
     }
 }

--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -244,7 +244,7 @@ class CollectorRegistry implements RegistryInterface
      * @param string     $name e.g. duration_seconds
      * @param string     $help e.g. A histogram of the duration in seconds.
      * @param string[]      $labels e.g. ['controller', 'action']
-     * @param mixed[]|null $buckets e.g. [100, 200, 300]
+     * @param float[]|null $buckets e.g. [100, 200, 300]
      *
      * @return Histogram
      * @throws MetricsRegistrationException

--- a/src/Prometheus/Counter.php
+++ b/src/Prometheus/Counter.php
@@ -19,7 +19,7 @@ class Counter extends Collector
     }
 
     /**
-     * @param array $labels e.g. ['status', 'opcode']
+     * @param string[] $labels e.g. ['status', 'opcode']
      */
     public function inc(array $labels = []): void
     {
@@ -28,9 +28,9 @@ class Counter extends Collector
 
     /**
      * @param int $count e.g. 2
-     * @param array $labels e.g. ['status', 'opcode']
+     * @param mixed[] $labels e.g. ['status', 'opcode']
      */
-    public function incBy($count, array $labels = []): void
+    public function incBy(int $count, array $labels = []): void
     {
         $this->assertLabelsAreDefinedCorrectly($labels);
 

--- a/src/Prometheus/Gauge.php
+++ b/src/Prometheus/Gauge.php
@@ -12,7 +12,7 @@ class Gauge extends Collector
 
     /**
      * @param double $value e.g. 123
-     * @param array $labels e.g. ['status', 'opcode']
+     * @param string[] $labels e.g. ['status', 'opcode']
      */
     public function set(float $value, array $labels = []): void
     {
@@ -40,16 +40,16 @@ class Gauge extends Collector
     }
 
     /**
-     * @param array $labels
+     * @param string[] $labels
      */
-    public function inc($labels = []): void
+    public function inc(array $labels = []): void
     {
         $this->incBy(1, $labels);
     }
 
     /**
-     * @param $value
-     * @param array $labels
+     * @param int|float $value
+     * @param string[] $labels
      */
     public function incBy($value, array $labels = []): void
     {
@@ -69,18 +69,18 @@ class Gauge extends Collector
     }
 
     /**
-     * @param array $labels
+     * @param string[] $labels
      */
-    public function dec($labels = []): void
+    public function dec(array $labels = []): void
     {
         $this->decBy(1, $labels);
     }
 
     /**
-     * @param $value
-     * @param array $labels
+     * @param int $value
+     * @param string[] $labels
      */
-    public function decBy($value, $labels = []): void
+    public function decBy(int $value, array $labels = []): void
     {
         $this->incBy(-$value, $labels);
     }

--- a/src/Prometheus/Histogram.php
+++ b/src/Prometheus/Histogram.php
@@ -12,27 +12,33 @@ class Histogram extends Collector
     const TYPE = 'histogram';
 
     /**
-     * @var array|null
+     * @var mixed[]|null
      */
     private $buckets;
 
     /**
-     * @param Adapter $adapter
-     * @param string $namespace
-     * @param string $name
-     * @param string $help
-     * @param array $labels
-     * @param array $buckets
+     * @param Adapter    $adapter
+     * @param string     $namespace
+     * @param string     $name
+     * @param string     $help
+     * @param string[]   $labels
+     * @param mixed[]|null $buckets
      */
-    public function __construct(Adapter $adapter, $namespace, $name, $help, $labels = [], $buckets = null)
-    {
+    public function __construct(
+        Adapter $adapter,
+        string $namespace,
+        string $name,
+        string $help,
+        array $labels = [],
+        array $buckets = null
+    ) {
         parent::__construct($adapter, $namespace, $name, $help, $labels);
 
         if (null === $buckets) {
             $buckets = self::getDefaultBuckets();
         }
 
-        if (0 == count($buckets)) {
+        if (0 === count($buckets)) {
             throw new InvalidArgumentException("Histogram must have at least one bucket.");
         }
 
@@ -52,20 +58,35 @@ class Histogram extends Collector
 
     /**
      * List of default buckets suitable for typical web application latency metrics
-     * @return array
+     *
+     * @return mixed[]
      */
     public static function getDefaultBuckets(): array
     {
         return [
-            0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+            0.005,
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            1.0,
+            2.5,
+            5.0,
+            7.5,
+            10.0,
         ];
     }
 
     /**
      * @param float $start
      * @param float $growthFactor
-     * @param int $numberOfBuckets
-     * @return array
+     * @param int   $numberOfBuckets
+     *
+     * @return mixed[]
      */
     public static function exponentialBuckets(float $start, float $growthFactor, int $numberOfBuckets): array
     {
@@ -85,7 +106,7 @@ class Histogram extends Collector
 
         for ($i = 0; $i < $numberOfBuckets; $i++) {
             $buckets[$i] = $start;
-            $start *= $growthFactor;
+            $start       *= $growthFactor;
         }
 
         return $buckets;
@@ -93,7 +114,7 @@ class Histogram extends Collector
 
     /**
      * @param double $value e.g. 123
-     * @param array $labels e.g. ['status', 'opcode']
+     * @param string[]  $labels e.g. ['status', 'opcode']
      */
     public function observe(float $value, array $labels = []): void
     {
@@ -101,13 +122,13 @@ class Histogram extends Collector
 
         $this->storageAdapter->updateHistogram(
             [
-                'value' => $value,
-                'name' => $this->getName(),
-                'help' => $this->getHelp(),
-                'type' => $this->getType(),
-                'labelNames' => $this->getLabelNames(),
+                'value'       => $value,
+                'name'        => $this->getName(),
+                'help'        => $this->getHelp(),
+                'type'        => $this->getType(),
+                'labelNames'  => $this->getLabelNames(),
                 'labelValues' => $labels,
-                'buckets' => $this->buckets,
+                'buckets'     => $this->buckets,
             ]
         );
     }

--- a/src/Prometheus/Histogram.php
+++ b/src/Prometheus/Histogram.php
@@ -12,7 +12,7 @@ class Histogram extends Collector
     const TYPE = 'histogram';
 
     /**
-     * @var mixed[]|null
+     * @var float[]|null
      */
     private $buckets;
 
@@ -22,7 +22,7 @@ class Histogram extends Collector
      * @param string     $name
      * @param string     $help
      * @param string[]   $labels
-     * @param mixed[]|null $buckets
+     * @param float[]|null $buckets
      */
     public function __construct(
         Adapter $adapter,
@@ -59,7 +59,7 @@ class Histogram extends Collector
     /**
      * List of default buckets suitable for typical web application latency metrics
      *
-     * @return mixed[]
+     * @return float[]
      */
     public static function getDefaultBuckets(): array
     {
@@ -86,7 +86,7 @@ class Histogram extends Collector
      * @param float $growthFactor
      * @param int   $numberOfBuckets
      *
-     * @return mixed[]
+     * @return float[]
      */
     public static function exponentialBuckets(float $start, float $growthFactor, int $numberOfBuckets): array
     {

--- a/src/Prometheus/MetricFamilySamples.php
+++ b/src/Prometheus/MetricFamilySamples.php
@@ -22,17 +22,17 @@ class MetricFamilySamples
     private $help;
 
     /**
-     * @var array
+     * @var string[]
      */
     private $labelNames;
 
     /**
-     * @var array
+     * @var Sample[]
      */
     private $samples = [];
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      */
     public function __construct(array $data)
     {
@@ -78,7 +78,7 @@ class MetricFamilySamples
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getLabelNames(): array
     {
@@ -90,6 +90,6 @@ class MetricFamilySamples
      */
     public function hasLabelNames(): bool
     {
-        return !empty($this->labelNames);
+        return $this->labelNames !== [];
     }
 }

--- a/src/Prometheus/RegistryInterface.php
+++ b/src/Prometheus/RegistryInterface.php
@@ -13,15 +13,15 @@ interface RegistryInterface
     public function getMetricFamilySamples(): array;
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. duration_seconds
-     * @param string $help e.g. The duration something took in seconds.
-     * @param array  $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. duration_seconds
+     * @param string   $help e.g. The duration something took in seconds.
+     * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Gauge
      * @throws MetricsRegistrationException
      */
-    public function registerGauge($namespace, $name, $help, $labels = []): Gauge;
+    public function registerGauge(string $namespace, string $name, string $help, array $labels = []): Gauge;
 
     /**
      * @param string $namespace
@@ -30,29 +30,29 @@ interface RegistryInterface
      * @return Gauge
      * @throws MetricNotFoundException
      */
-    public function getGauge($namespace, $name): Gauge;
+    public function getGauge(string $namespace, string $name): Gauge;
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. duration_seconds
-     * @param string $help e.g. The duration something took in seconds.
-     * @param array  $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. duration_seconds
+     * @param string   $help e.g. The duration something took in seconds.
+     * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Gauge
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterGauge($namespace, $name, $help, $labels = []): Gauge;
+    public function getOrRegisterGauge(string $namespace, string $name, string $help, array $labels = []): Gauge;
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. requests
-     * @param string $help e.g. The number of requests made.
-     * @param array  $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. requests
+     * @param string   $help e.g. The number of requests made.
+     * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Counter
      * @throws MetricsRegistrationException
      */
-    public function registerCounter($namespace, $name, $help, $labels = []): Counter;
+    public function registerCounter(string $namespace, string $name, string $help, array $labels = []): Counter;
 
     /**
      * @param string $namespace
@@ -61,49 +61,55 @@ interface RegistryInterface
      * @return Counter
      * @throws MetricNotFoundException
      */
-    public function getCounter($namespace, $name): Counter;
+    public function getCounter(string $namespace, string $name): Counter;
 
     /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. requests
-     * @param string $help e.g. The number of requests made.
-     * @param array  $labels e.g. ['controller', 'action']
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. requests
+     * @param string   $help e.g. The number of requests made.
+     * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Counter
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterCounter($namespace, $name, $help, $labels = []): Counter;
+    public function getOrRegisterCounter(string $namespace, string $name, string $help, array $labels = []): Counter;
+
+    /**
+     * @param string   $namespace e.g. cms
+     * @param string   $name e.g. duration_seconds
+     * @param string   $help e.g. A histogram of the duration in seconds.
+     * @param string[] $labels e.g. ['controller', 'action']
+     * @param int[]    $buckets e.g. [100, 200, 300]
+     *
+     * @return Histogram
+     * @throws MetricsRegistrationException
+     */
+    public function registerHistogram(
+        string $namespace,
+        string $name,
+        string $help,
+        array $labels = [],
+        array $buckets = null
+    ): Histogram;
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return Histogram
+     * @throws MetricNotFoundException
+     */
+    public function getHistogram(string $namespace, string $name): Histogram;
 
     /**
      * @param string $namespace e.g. cms
      * @param string $name e.g. duration_seconds
      * @param string $help e.g. A histogram of the duration in seconds.
-     * @param array  $labels e.g. ['controller', 'action']
-     * @param array  $buckets e.g. [100, 200, 300]
+     * @param string[]  $labels e.g. ['controller', 'action']
+     * @param int[]  $buckets e.g. [100, 200, 300]
      *
      * @return Histogram
      * @throws MetricsRegistrationException
      */
-    public function registerHistogram($namespace, $name, $help, $labels = [], $buckets = null): Histogram;
-
-    /**
-     * @param string $namespace
-     * @param string $name
-     *
-     * @return Histogram
-     * @throws MetricNotFoundException
-     */
-    public function getHistogram($namespace, $name): Histogram;
-
-    /**
-     * @param string $namespace e.g. cms
-     * @param string $name e.g. duration_seconds
-     * @param string $help e.g. A histogram of the duration in seconds.
-     * @param array  $labels e.g. ['controller', 'action']
-     * @param array  $buckets e.g. [100, 200, 300]
-     *
-     * @return Histogram
-     * @throws MetricsRegistrationException
-     */
-    public function getOrRegisterHistogram($namespace, $name, $help, $labels = [], $buckets = null): Histogram;
+    public function getOrRegisterHistogram(string $namespace, string $name, string $help, array $labels = [], array $buckets = null): Histogram;
 }

--- a/src/Prometheus/RegistryInterface.php
+++ b/src/Prometheus/RegistryInterface.php
@@ -79,7 +79,7 @@ interface RegistryInterface
      * @param string   $name e.g. duration_seconds
      * @param string   $help e.g. A histogram of the duration in seconds.
      * @param string[] $labels e.g. ['controller', 'action']
-     * @param int[]    $buckets e.g. [100, 200, 300]
+     * @param float[]    $buckets e.g. [100, 200, 300]
      *
      * @return Histogram
      * @throws MetricsRegistrationException
@@ -106,7 +106,7 @@ interface RegistryInterface
      * @param string $name e.g. duration_seconds
      * @param string $help e.g. A histogram of the duration in seconds.
      * @param string[]  $labels e.g. ['controller', 'action']
-     * @param int[]  $buckets e.g. [100, 200, 300]
+     * @param float[]  $buckets e.g. [100, 200, 300]
      *
      * @return Histogram
      * @throws MetricsRegistrationException

--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -14,7 +14,7 @@ class RenderTextFormat implements RendererInterface
      */
     public function render(array $metrics): string
     {
-        usort($metrics, function (MetricFamilySamples $a, MetricFamilySamples $b) {
+        usort($metrics, function (MetricFamilySamples $a, MetricFamilySamples $b): int {
             return strcmp($a->getName(), $b->getName());
         });
 
@@ -36,14 +36,9 @@ class RenderTextFormat implements RendererInterface
      */
     private function renderSample(MetricFamilySamples $metric, Sample $sample): string
     {
-        $escapedLabels = [];
-
         $labelNames = $metric->getLabelNames();
         if ($metric->hasLabelNames() || $sample->hasLabelNames()) {
-            $labels = array_combine(array_merge($labelNames, $sample->getLabelNames()), $sample->getLabelValues());
-            foreach ($labels as $labelName => $labelValue) {
-                $escapedLabels[] = $labelName . '="' . $this->escapeLabelValue($labelValue) . '"';
-            }
+            $escapedLabels = $this->escapeAllLabels($labelNames, $sample);
             return $sample->getName() . '{' . implode(',', $escapedLabels) . '} ' . $sample->getValue();
         }
         return $sample->getName() . ' ' . $sample->getValue();
@@ -53,11 +48,31 @@ class RenderTextFormat implements RendererInterface
      * @param string $v
      * @return string
      */
-    private function escapeLabelValue($v): string
+    private function escapeLabelValue(string $v): string
     {
-        $v = str_replace("\\", "\\\\", $v);
-        $v = str_replace("\n", "\\n", $v);
-        $v = str_replace("\"", "\\\"", $v);
-        return $v;
+        return str_replace(["\\", "\n", "\""], ["\\\\", "\\n", "\\\""], $v);
+    }
+
+    /**
+     * @param string[]  $labelNames
+     * @param Sample $sample
+     *
+     * @return string[]
+     */
+    private function escapeAllLabels(array $labelNames, Sample $sample): array
+    {
+        $escapedLabels = [];
+
+        $labels = array_combine(array_merge($labelNames, $sample->getLabelNames()), $sample->getLabelValues());
+
+        if ($labels === false) {
+            return [];
+        }
+
+        foreach ($labels as $labelName => $labelValue) {
+            $escapedLabels[] = $labelName . '="' . $this->escapeLabelValue((string) $labelValue) . '"';
+        }
+
+        return $escapedLabels;
     }
 }

--- a/src/Prometheus/Sample.php
+++ b/src/Prometheus/Sample.php
@@ -12,12 +12,12 @@ class Sample
     private $name;
 
     /**
-     * @var array
+     * @var string[]
      */
     private $labelNames;
 
     /**
-     * @var array
+     * @var mixed[]
      */
     private $labelValues;
 
@@ -28,13 +28,13 @@ class Sample
 
     /**
      * Sample constructor.
-     * @param array $data
+     * @param mixed[] $data
      */
     public function __construct(array $data)
     {
         $this->name = $data['name'];
-        $this->labelNames = $data['labelNames'];
-        $this->labelValues = $data['labelValues'];
+        $this->labelNames = (array) $data['labelNames'];
+        $this->labelValues = (array) $data['labelValues'];
         $this->value = $data['value'];
     }
 
@@ -47,23 +47,23 @@ class Sample
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getLabelNames(): array
     {
-        return (array)$this->labelNames;
+        return $this->labelNames;
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getLabelValues(): array
     {
-        return (array)$this->labelValues;
+        return $this->labelValues;
     }
 
     /**
-     * @return int|double
+     * @return string
      */
     public function getValue(): string
     {
@@ -75,6 +75,6 @@ class Sample
      */
     public function hasLabelNames(): bool
     {
-        return !empty($this->labelNames);
+        return $this->labelNames !== [];
     }
 }

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -132,7 +132,7 @@ class APC implements Adapter
 
     /**
      * @param mixed[] $data
-     * @param mixed $bucket
+     * @param string|int $bucket
      * @return string
      */
     private function histogramBucketValueKey(array $data, $bucket): string

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -24,7 +24,7 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      */
     public function updateHistogram(array $data): void
     {
@@ -62,12 +62,12 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      */
     public function updateGauge(array $data): void
     {
         $valueKey = $this->valueKey($data);
-        if ($data['command'] == Adapter::COMMAND_SET) {
+        if ($data['command'] === Adapter::COMMAND_SET) {
             apcu_store($valueKey, $this->toInteger($data['value']));
             apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
         } else {
@@ -87,7 +87,7 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      */
     public function updateCounter(array $data): void
     {
@@ -107,7 +107,7 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @return string
      */
     private function metaKey(array $data): string
@@ -116,7 +116,7 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @return string
      */
     private function valueKey(array $data): string
@@ -131,7 +131,8 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
+     * @param mixed $bucket
      * @return string
      */
     private function histogramBucketValueKey(array $data, $bucket): string
@@ -147,8 +148,8 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $data
-     * @return array
+     * @param mixed[] $data
+     * @return mixed[]
      */
     private function metaData(array $data): array
     {
@@ -158,7 +159,7 @@ class APC implements Adapter
     }
 
     /**
-     * @return array
+     * @return MetricFamilySamples[]
      */
     private function collectCounters(): array
     {
@@ -170,6 +171,7 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'samples' => [],
             ];
             foreach (new APCUIterator('/^prom:counter:' . $metaData['name'] . ':.*:value/') as $value) {
                 $parts = explode(':', $value['key']);
@@ -188,7 +190,7 @@ class APC implements Adapter
     }
 
     /**
-     * @return array
+     * @return MetricFamilySamples[]
      */
     private function collectGauges(): array
     {
@@ -200,6 +202,7 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'samples' => [],
             ];
             foreach (new APCUIterator('/^prom:gauge:' . $metaData['name'] . ':.*:value/') as $value) {
                 $parts = explode(':', $value['key']);
@@ -219,7 +222,7 @@ class APC implements Adapter
     }
 
     /**
-     * @return array
+     * @return MetricFamilySamples[]
      */
     private function collectHistograms(): array
     {
@@ -312,17 +315,17 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $samples
+     * @param mixed[] $samples
      */
     private function sortSamples(array &$samples): void
     {
-        usort($samples, function ($a, $b) {
+        usort($samples, function ($a, $b): int {
             return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
         });
     }
 
     /**
-     * @param array $values
+     * @param mixed[] $values
      * @return string
      * @throws RuntimeException
      */
@@ -337,10 +340,10 @@ class APC implements Adapter
 
     /**
      * @param string $values
-     * @return array
+     * @return mixed[]
      * @throws RuntimeException
      */
-    private function decodeLabelValues($values): array
+    private function decodeLabelValues(string $values): array
     {
         $json = base64_decode($values, true);
         if (false === $json) {

--- a/src/Prometheus/Storage/Adapter.php
+++ b/src/Prometheus/Storage/Adapter.php
@@ -15,22 +15,22 @@ interface Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    public function collect();
+    public function collect(): array;
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @return void
      */
     public function updateHistogram(array $data): void;
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @return void
      */
     public function updateGauge(array $data): void;
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @return void
      */
     public function updateCounter(array $data): void;

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -10,8 +10,19 @@ use RuntimeException;
 class InMemory implements Adapter
 {
 
+    /**
+     * @var mixed[]
+     */
     private $counters = [];
+
+    /**
+     * @var mixed[]
+     */
     private $gauges = [];
+
+    /**
+     * @var mixed[]
+     */
     private $histograms = [];
 
     /**
@@ -33,7 +44,7 @@ class InMemory implements Adapter
     }
 
     /**
-     * @return array
+     * @return MetricFamilySamples[]
      */
     private function collectHistograms(): array
     {
@@ -108,8 +119,8 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $metrics
-     * @return array
+     * @param mixed[] $metrics
+     * @return MetricFamilySamples[]
      */
     private function internalCollect(array $metrics): array
     {
@@ -121,6 +132,7 @@ class InMemory implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'samples' => [],
             ];
             foreach ($metric['samples'] as $key => $value) {
                 $parts = explode(':', $key);
@@ -139,7 +151,7 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @return void
      */
     public function updateHistogram(array $data): void
@@ -176,7 +188,7 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      */
     public function updateGauge(array $data): void
     {
@@ -199,7 +211,7 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      */
     public function updateCounter(array $data): void
     {
@@ -222,8 +234,9 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $data
-     * @param string $bucket
+     * @param mixed[]    $data
+     * @param string|int $bucket
+     *
      * @return string
      */
     private function histogramBucketValueKey(array $data, $bucket): string
@@ -237,7 +250,7 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      *
      * @return string
      */
@@ -251,7 +264,7 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      *
      * @return string
      */
@@ -266,31 +279,29 @@ class InMemory implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      *
-     * @return array
+     * @return mixed[]
      */
     private function metaData(array $data): array
     {
         $metricsMetaData = $data;
-        unset($metricsMetaData['value']);
-        unset($metricsMetaData['command']);
-        unset($metricsMetaData['labelValues']);
+        unset($metricsMetaData['value'], $metricsMetaData['command'], $metricsMetaData['labelValues']);
         return $metricsMetaData;
     }
 
     /**
-     * @param array $samples
+     * @param mixed[] $samples
      */
     private function sortSamples(array &$samples): void
     {
-        usort($samples, function ($a, $b) {
+        usort($samples, function ($a, $b): int {
             return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
         });
     }
 
     /**
-     * @param array $values
+     * @param mixed[] $values
      * @return string
      * @throws RuntimeException
      */
@@ -305,10 +316,10 @@ class InMemory implements Adapter
 
     /**
      * @param string $values
-     * @return array
+     * @return mixed[]
      * @throws RuntimeException
      */
-    private function decodeLabelValues($values): array
+    private function decodeLabelValues(string $values): array
     {
         $json = base64_decode($values, true);
         if (false === $json) {

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -16,7 +16,7 @@ class Redis implements Adapter
     const PROMETHEUS_METRIC_KEYS_SUFFIX = '_METRIC_KEYS';
 
     /**
-     * @var array
+     * @var mixed[]
      */
     private static $defaultOptions = [
         'host' => '127.0.0.1',
@@ -33,7 +33,7 @@ class Redis implements Adapter
     private static $prefix = 'PROMETHEUS_';
 
     /**
-     * @var array
+     * @var mixed[]
      */
     private $options = [];
 
@@ -49,7 +49,7 @@ class Redis implements Adapter
 
     /**
      * Redis constructor.
-     * @param array $options
+     * @param mixed[] $options
      */
     public function __construct(array $options = [])
     {
@@ -59,7 +59,7 @@ class Redis implements Adapter
 
     /**
      * @param \Redis $redis
-     * @return static
+     * @return self
      * @throws StorageException
      */
     public static function fromExistingConnection(\Redis $redis): self
@@ -76,7 +76,7 @@ class Redis implements Adapter
     }
 
     /**
-     * @param array $options
+     * @param mixed[] $options
      */
     public static function setDefaultOptions(array $options): void
     {
@@ -111,7 +111,7 @@ class Redis implements Adapter
         $metrics = array_merge($metrics, $this->collectGauges());
         $metrics = array_merge($metrics, $this->collectCounters());
         return array_map(
-            function (array $metric) {
+            function (array $metric): MetricFamilySamples {
                 return new MetricFamilySamples($metric);
             },
             $metrics
@@ -129,7 +129,7 @@ class Redis implements Adapter
 
         $this->connectToServer();
 
-        if ($this->options['password']) {
+        if ($this->options['password'] !== null) {
             $this->redis->auth($this->options['password']);
         }
 
@@ -147,7 +147,7 @@ class Redis implements Adapter
     {
         try {
             $connection_successful = false;
-            if ($this->options['persistent_connections']) {
+            if ($this->options['persistent_connections'] !== null) {
                 $connection_successful = $this->redis->pconnect(
                     $this->options['host'],
                     (int) $this->options['port'],
@@ -165,7 +165,7 @@ class Redis implements Adapter
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @throws StorageException
      */
     public function updateHistogram(array $data): void
@@ -204,7 +204,7 @@ LUA
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @throws StorageException
      */
     public function updateGauge(array $data): void
@@ -242,7 +242,7 @@ LUA
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @throws StorageException
      */
     public function updateCounter(array $data): void
@@ -273,7 +273,7 @@ LUA
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     private function collectHistograms(): array
     {
@@ -350,7 +350,7 @@ LUA
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     private function collectGauges(): array
     {
@@ -370,7 +370,7 @@ LUA
                     'value' => $value,
                 ];
             }
-            usort($gauge['samples'], function ($a, $b) {
+            usort($gauge['samples'], function ($a, $b): int {
                 return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
             });
             $gauges[] = $gauge;
@@ -379,7 +379,7 @@ LUA
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     private function collectCounters(): array
     {
@@ -399,7 +399,7 @@ LUA
                     'value' => $value,
                 ];
             }
-            usort($counter['samples'], function ($a, $b) {
+            usort($counter['samples'], function ($a, $b): int {
                 return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
             });
             $counters[] = $counter;
@@ -426,7 +426,7 @@ LUA
     }
 
     /**
-     * @param array $data
+     * @param mixed[] $data
      * @return string
      */
     private function toMetricKey(array $data): string

--- a/tests/Test/Prometheus/APC/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APC/CollectorRegistryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\APC;
 
 use Prometheus\Storage\APC;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractCollectorRegistryTest;
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
 
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new APC();
         $this->adapter->flushAPC();

--- a/tests/Test/Prometheus/APC/CounterTest.php
+++ b/tests/Test/Prometheus/APC/CounterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\APC;
 
 use Prometheus\Storage\APC;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractCounterTest;
  */
 class CounterTest extends AbstractCounterTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new APC();
         $this->adapter->flushAPC();

--- a/tests/Test/Prometheus/APC/GaugeTest.php
+++ b/tests/Test/Prometheus/APC/GaugeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\APC;
 
 use Prometheus\Storage\APC;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractGaugeTest;
  */
 class GaugeTest extends AbstractGaugeTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new APC();
         $this->adapter->flushAPC();

--- a/tests/Test/Prometheus/APC/HistogramTest.php
+++ b/tests/Test/Prometheus/APC/HistogramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\APC;
 
 use Prometheus\Storage\APC;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractHistogramTest;
  */
 class HistogramTest extends AbstractHistogramTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new APC();
         $this->adapter->flushAPC();

--- a/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
+++ b/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus;
 
 use PHPUnit\Framework\TestCase;
 use Prometheus\CollectorRegistry;
-use Prometheus\Histogram;
 use Prometheus\RenderTextFormat;
 use Prometheus\Storage\Adapter;
-use Prometheus\Storage\Redis;
 use Prometheus\Exception\MetricsRegistrationException;
 use Prometheus\Exception\MetricNotFoundException;
 
@@ -32,7 +32,7 @@ abstract class AbstractCollectorRegistryTest extends TestCase
     /**
      * @test
      */
-    public function itShouldHaveDefaultMetrics()
+    public function itShouldHaveDefaultMetrics(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $expected = <<<EOF
@@ -41,9 +41,9 @@ abstract class AbstractCollectorRegistryTest extends TestCase
 php_info{version="%s"} 1
 
 EOF;
-        $this->assertThat(
+        self::assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->stringContains(
+            self::stringContains(
                 sprintf($expected, phpversion())
             )
         );
@@ -52,7 +52,7 @@ EOF;
     /**
      * @test
      */
-    public function itShouldNotHaveDefaultMetricsWhenTheyAreDisabled()
+    public function itShouldNotHaveDefaultMetricsWhenTheyAreDisabled(): void
     {
         $registry = new CollectorRegistry($this->adapter, false);
         $expected = <<<EOF
@@ -61,7 +61,7 @@ EOF;
 php_info{version="%s"} 1
 
 EOF;
-        $this->assertStringNotContainsString(
+        self::assertStringNotContainsString(
             sprintf($expected, phpversion()),
             $this->renderer->render($registry->getMetricFamilySamples())
         );
@@ -71,7 +71,7 @@ EOF;
     /**
      * @test
      */
-    public function itShouldSaveGauges()
+    public function itShouldSaveGauges(): void
     {
         $registry = new CollectorRegistry($this->adapter);
 
@@ -83,9 +83,9 @@ EOF;
 
 
         $registry = new CollectorRegistry($this->adapter);
-        $this->assertThat(
+        self::assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->stringContains(
+            self::stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric gauge
@@ -102,7 +102,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldSaveCounters()
+    public function itShouldSaveCounters(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $metric = $registry->registerCounter('test', 'some_metric', 'this is for testing', ['foo', 'bar']);
@@ -111,9 +111,9 @@ EOF
         $registry->getCounter('test', 'some_metric')->inc(['lalal', 'lvlvlv']);
 
         $registry = new CollectorRegistry($this->adapter);
-        $this->assertThat(
+        self::assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->stringContains(
+            self::stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric counter
@@ -128,7 +128,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldSaveHistograms()
+    public function itShouldSaveHistograms(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $metric = $registry->registerHistogram(
@@ -145,9 +145,9 @@ EOF
         $registry->getHistogram('test', 'some_metric')->observe(7.1, ['gnaaha', 'hihihi']);
 
         $registry = new CollectorRegistry($this->adapter);
-        $this->assertThat(
+        self::assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->stringContains(
+            self::stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric histogram
@@ -181,7 +181,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldSaveHistogramsWithoutLabels()
+    public function itShouldSaveHistogramsWithoutLabels(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $metric = $registry->registerHistogram('test', 'some_metric', 'this is for testing');
@@ -190,9 +190,9 @@ EOF
         $registry->getHistogram('test', 'some_metric')->observe(7.1);
 
         $registry = new CollectorRegistry($this->adapter);
-        $this->assertThat(
+        self::assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->stringContains(
+            self::stringContains(
                 <<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric histogram
@@ -222,16 +222,16 @@ EOF
     /**
      * @test
      */
-    public function itShouldIncreaseACounterWithoutNamespace()
+    public function itShouldIncreaseACounterWithoutNamespace(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $registry
             ->registerCounter('', 'some_quick_counter', 'just a quick measurement')
             ->inc();
 
-        $this->assertThat(
+        self::assertThat(
             $this->renderer->render($registry->getMetricFamilySamples()),
-            $this->stringContains(
+            self::stringContains(
                 <<<EOF
 # HELP some_quick_counter just a quick measurement
 # TYPE some_quick_counter counter
@@ -245,7 +245,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldForbidRegisteringTheSameCounterTwice()
+    public function itShouldForbidRegisteringTheSameCounterTwice(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $registry->registerCounter('foo', 'metric', 'help');
@@ -257,7 +257,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldForbidRegisteringTheSameCounterWithDifferentLabels()
+    public function itShouldForbidRegisteringTheSameCounterWithDifferentLabels(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $registry->registerCounter('foo', 'metric', 'help', ["foo", "bar"]);
@@ -269,7 +269,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldForbidRegisteringTheSameHistogramTwice()
+    public function itShouldForbidRegisteringTheSameHistogramTwice(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $registry->registerHistogram('foo', 'metric', 'help');
@@ -281,7 +281,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldForbidRegisteringTheSameHistogramWithDifferentLabels()
+    public function itShouldForbidRegisteringTheSameHistogramWithDifferentLabels(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $registry->registerCounter('foo', 'metric', 'help', ["foo", "bar"]);
@@ -293,7 +293,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldForbidRegisteringTheSameGaugeTwice()
+    public function itShouldForbidRegisteringTheSameGaugeTwice(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $registry->registerGauge('foo', 'metric', 'help');
@@ -305,7 +305,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldForbidRegisteringTheSameGaugeWithDifferentLabels()
+    public function itShouldForbidRegisteringTheSameGaugeWithDifferentLabels(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $registry->registerGauge('foo', 'metric', 'help', ["foo", "bar"]);
@@ -317,7 +317,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldThrowAnExceptionWhenGettingANonExistentMetric()
+    public function itShouldThrowAnExceptionWhenGettingANonExistentMetric(): void
     {
         $registry = new CollectorRegistry($this->adapter);
 
@@ -328,39 +328,39 @@ EOF
     /**
      * @test
      */
-    public function itShouldNotRegisterACounterTwice()
+    public function itShouldNotRegisterACounterTwice(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $counterA = $registry->getOrRegisterCounter("foo", "bar", "Help text");
         $counterB = $registry->getOrRegisterCounter("foo", "bar", "Help text");
 
-        $this->assertSame($counterA, $counterB);
+        self::assertSame($counterA, $counterB);
     }
 
     /**
      * @test
      */
-    public function itShouldNotRegisterAGaugeTwice()
+    public function itShouldNotRegisterAGaugeTwice(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $gaugeA = $registry->getOrRegisterGauge("foo", "bar", "Help text");
         $gaugeB = $registry->getOrRegisterGauge("foo", "bar", "Help text");
 
-        $this->assertSame($gaugeA, $gaugeB);
+        self::assertSame($gaugeA, $gaugeB);
     }
 
     /**
      * @test
      */
-    public function itShouldNotRegisterAHistogramTwice()
+    public function itShouldNotRegisterAHistogramTwice(): void
     {
         $registry = new CollectorRegistry($this->adapter);
         $histogramA = $registry->getOrRegisterHistogram("foo", "bar", "Help text");
         $histogramB = $registry->getOrRegisterHistogram("foo", "bar", "Help text");
 
-        $this->assertSame($histogramA, $histogramB);
+        self::assertSame($histogramA, $histogramB);
     }
 
 
-    abstract public function configureAdapter();
+    abstract public function configureAdapter(): void;
 }

--- a/tests/Test/Prometheus/AbstractCounterTest.php
+++ b/tests/Test/Prometheus/AbstractCounterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus;
 
 use InvalidArgumentException;
@@ -24,20 +26,20 @@ abstract class AbstractCounterTest extends TestCase
         $this->configureAdapter();
     }
 
-    abstract public function configureAdapter();
+    abstract public function configureAdapter(): void;
 
     /**
      * @test
      */
-    public function itShouldIncreaseWithLabels()
+    public function itShouldIncreaseWithLabels(): void
     {
         $counter = new Counter($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $counter->inc(['lalal', 'lululu']);
         $counter->inc(['lalal', 'lululu']);
         $counter->inc(['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -63,13 +65,13 @@ abstract class AbstractCounterTest extends TestCase
     /**
      * @test
      */
-    public function itShouldIncreaseWithoutLabelWhenNoLabelsAreDefined()
+    public function itShouldIncreaseWithoutLabelWhenNoLabelsAreDefined(): void
     {
         $counter = new Counter($this->adapter, 'test', 'some_metric', 'this is for testing');
         $counter->inc();
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -95,14 +97,14 @@ abstract class AbstractCounterTest extends TestCase
     /**
      * @test
      */
-    public function itShouldIncreaseTheCounterByAnArbitraryInteger()
+    public function itShouldIncreaseTheCounterByAnArbitraryInteger(): void
     {
         $counter = new Counter($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $counter->inc(['lalal', 'lululu']);
         $counter->incBy(123, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -128,7 +130,7 @@ abstract class AbstractCounterTest extends TestCase
     /**
      * @test
      */
-    public function itShouldRejectInvalidMetricsNames()
+    public function itShouldRejectInvalidMetricsNames(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new Counter($this->adapter, 'test', 'some metric invalid metric', 'help');
@@ -137,7 +139,7 @@ abstract class AbstractCounterTest extends TestCase
     /**
      * @test
      */
-    public function itShouldRejectInvalidLabelNames()
+    public function itShouldRejectInvalidLabelNames(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new Counter($this->adapter, 'test', 'some_metric', 'help', ['invalid label']);
@@ -149,35 +151,36 @@ abstract class AbstractCounterTest extends TestCase
      *
      * @param mixed $value The label value
      */
-    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value)
+    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value): void
     {
         $label = 'foo';
         $histogram = new Counter($this->adapter, 'test', 'some_metric', 'help', [$label]);
         $histogram->inc([$value]);
 
         $metrics = $this->adapter->collect();
-        $this->assertIsArray($metrics);
-        $this->assertCount(1, $metrics);
-        $this->assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
+        self::assertCount(1, $metrics);
+        self::assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
 
         $metric = reset($metrics);
+        self::assertInstanceOf(MetricFamilySamples::class, $metric);
         $samples = $metric->getSamples();
-        $this->assertContainsOnlyInstancesOf(Sample::class, $samples);
+        self::assertContainsOnlyInstancesOf(Sample::class, $samples);
 
         foreach ($samples as $sample) {
             $labels = array_combine(
                 array_merge($metric->getLabelNames(), $sample->getLabelNames()),
                 $sample->getLabelValues()
             );
-            $this->assertEquals($value, $labels[$label]);
+            self::assertIsArray($labels);
+            self::assertEquals($value, $labels[$label]);
         }
     }
 
     /**
-     * @return array
+     * @return mixed[]
      * @see isShouldAcceptArbitraryLabelValues
      */
-    public function labelValuesDataProvider()
+    public function labelValuesDataProvider(): array
     {
         $cases = [];
         // Basic Latin

--- a/tests/Test/Prometheus/AbstractGaugeTest.php
+++ b/tests/Test/Prometheus/AbstractGaugeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus;
 
 use InvalidArgumentException;
@@ -24,18 +26,18 @@ abstract class AbstractGaugeTest extends TestCase
         $this->configureAdapter();
     }
 
-    abstract public function configureAdapter();
+    abstract public function configureAdapter(): void;
 
     /**
      * @test
      */
-    public function itShouldAllowSetWithLabels()
+    public function itShouldAllowSetWithLabels(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $gauge->set(123, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -56,20 +58,20 @@ abstract class AbstractGaugeTest extends TestCase
                 ]
             )
         );
-        $this->assertThat($gauge->getHelp(), $this->equalTo('this is for testing'));
-        $this->assertThat($gauge->getType(), $this->equalTo(Gauge::TYPE));
+        self::assertThat($gauge->getHelp(), self::equalTo('this is for testing'));
+        self::assertThat($gauge->getType(), self::equalTo(Gauge::TYPE));
     }
 
     /**
      * @test
      */
-    public function itShouldAllowSetWithoutLabelWhenNoLabelsAreDefined()
+    public function itShouldAllowSetWithoutLabelWhenNoLabelsAreDefined(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing');
         $gauge->set(123);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -90,20 +92,20 @@ abstract class AbstractGaugeTest extends TestCase
                 ]
             )
         );
-        $this->assertThat($gauge->getHelp(), $this->equalTo('this is for testing'));
-        $this->assertThat($gauge->getType(), $this->equalTo(Gauge::TYPE));
+        self::assertThat($gauge->getHelp(), self::equalTo('this is for testing'));
+        self::assertThat($gauge->getType(), self::equalTo(Gauge::TYPE));
     }
 
     /**
      * @test
      */
-    public function itShouldAllowSetWithAFloatValue()
+    public function itShouldAllowSetWithAFloatValue(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing');
         $gauge->set(123.5);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -124,21 +126,21 @@ abstract class AbstractGaugeTest extends TestCase
                 ]
             )
         );
-        $this->assertThat($gauge->getHelp(), $this->equalTo('this is for testing'));
-        $this->assertThat($gauge->getType(), $this->equalTo(Gauge::TYPE));
+        self::assertThat($gauge->getHelp(), self::equalTo('this is for testing'));
+        self::assertThat($gauge->getType(), self::equalTo(Gauge::TYPE));
     }
 
     /**
      * @test
      */
-    public function itShouldIncrementAValue()
+    public function itShouldIncrementAValue(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $gauge->inc(['lalal', 'lululu']);
         $gauge->incBy(123, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -164,14 +166,14 @@ abstract class AbstractGaugeTest extends TestCase
     /**
      * @test
      */
-    public function itShouldIncrementWithFloatValue()
+    public function itShouldIncrementWithFloatValue(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $gauge->inc(['lalal', 'lululu']);
         $gauge->incBy(123.5, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -197,14 +199,14 @@ abstract class AbstractGaugeTest extends TestCase
     /**
      * @test
      */
-    public function itShouldDecrementAValue()
+    public function itShouldDecrementAValue(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $gauge->dec(['lalal', 'lululu']);
         $gauge->decBy(123, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -230,14 +232,14 @@ abstract class AbstractGaugeTest extends TestCase
     /**
      * @test
      */
-    public function itShouldDecrementWithFloatValue()
+    public function itShouldDecrementWithFloatValue(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $gauge->dec(['lalal', 'lululu']);
         $gauge->decBy(123, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -263,14 +265,14 @@ abstract class AbstractGaugeTest extends TestCase
     /**
      * @test
      */
-    public function itShouldOverwriteWhenSettingTwice()
+    public function itShouldOverwriteWhenSettingTwice(): void
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
         $gauge->set(123, ['lalal', 'lululu']);
         $gauge->set(321, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -296,7 +298,7 @@ abstract class AbstractGaugeTest extends TestCase
     /**
      * @test
      */
-    public function itShouldRejectInvalidMetricsNames()
+    public function itShouldRejectInvalidMetricsNames(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new Gauge($this->adapter, 'test', 'some metric invalid metric', 'help');
@@ -305,7 +307,7 @@ abstract class AbstractGaugeTest extends TestCase
     /**
      * @test
      */
-    public function itShouldRejectInvalidLabelNames()
+    public function itShouldRejectInvalidLabelNames(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new Gauge($this->adapter, 'test', 'some_metric', 'help', ['invalid label']);
@@ -317,35 +319,36 @@ abstract class AbstractGaugeTest extends TestCase
      *
      * @param mixed $value The label value
      */
-    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value)
+    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value): void
     {
         $label = 'foo';
         $histogram = new Gauge($this->adapter, 'test', 'some_metric', 'help', [$label]);
         $histogram->inc([$value]);
 
         $metrics = $this->adapter->collect();
-        $this->assertIsArray($metrics);
-        $this->assertCount(1, $metrics);
-        $this->assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
+        self::assertCount(1, $metrics);
+        self::assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
 
         $metric = reset($metrics);
+        self::assertInstanceOf(MetricFamilySamples::class, $metric);
         $samples = $metric->getSamples();
-        $this->assertContainsOnlyInstancesOf(Sample::class, $samples);
+        self::assertContainsOnlyInstancesOf(Sample::class, $samples);
 
         foreach ($samples as $sample) {
             $labels = array_combine(
                 array_merge($metric->getLabelNames(), $sample->getLabelNames()),
                 $sample->getLabelValues()
             );
-            $this->assertEquals($value, $labels[$label]);
+            self::assertIsArray($labels);
+            self::assertEquals($value, $labels[$label]);
         }
     }
 
     /**
-     * @return array
+     * @return mixed[]
      * @see isShouldAcceptArbitraryLabelValues
      */
-    public function labelValuesDataProvider()
+    public function labelValuesDataProvider(): array
     {
         $cases = [];
         // Basic Latin

--- a/tests/Test/Prometheus/AbstractHistogramTest.php
+++ b/tests/Test/Prometheus/AbstractHistogramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus;
 
 use InvalidArgumentException;
@@ -24,12 +26,12 @@ abstract class AbstractHistogramTest extends TestCase
         $this->configureAdapter();
     }
 
-    abstract public function configureAdapter();
+    abstract public function configureAdapter(): void;
 
     /**
      * @test
      */
-    public function itShouldObserveWithLabels()
+    public function itShouldObserveWithLabels(): void
     {
         $histogram = new Histogram(
             $this->adapter,
@@ -41,9 +43,9 @@ abstract class AbstractHistogramTest extends TestCase
         );
         $histogram->observe(123, ['lalal', 'lululu']);
         $histogram->observe(245, ['lalal', 'lululu']);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -99,7 +101,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldObserveWithoutLabelWhenNoLabelsAreDefined()
+    public function itShouldObserveWithoutLabelWhenNoLabelsAreDefined(): void
     {
         $histogram = new Histogram(
             $this->adapter,
@@ -110,9 +112,9 @@ abstract class AbstractHistogramTest extends TestCase
             [100, 200, 300]
         );
         $histogram->observe(245);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -168,7 +170,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldObserveValuesOfTypeDouble()
+    public function itShouldObserveValuesOfTypeDouble(): void
     {
         $histogram = new Histogram(
             $this->adapter,
@@ -180,9 +182,9 @@ abstract class AbstractHistogramTest extends TestCase
         );
         $histogram->observe(0.11);
         $histogram->observe(0.3);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -238,7 +240,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldProvideDefaultBuckets()
+    public function itShouldProvideDefaultBuckets(): void
     {
         // .005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0
 
@@ -251,9 +253,9 @@ abstract class AbstractHistogramTest extends TestCase
         );
         $histogram->observe(0.11);
         $histogram->observe(0.03);
-        $this->assertThat(
+        self::assertThat(
             $this->adapter->collect(),
-            $this->equalTo(
+            self::equalTo(
                 [
                     new MetricFamilySamples(
                         [
@@ -375,7 +377,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldThrowAnExceptionWhenTheBucketSizesAreNotIncreasing()
+    public function itShouldThrowAnExceptionWhenTheBucketSizesAreNotIncreasing(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Histogram buckets must be in increasing order');
@@ -385,7 +387,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldThrowAnExceptionWhenThereIsLessThanOneBucket()
+    public function itShouldThrowAnExceptionWhenThereIsLessThanOneBucket(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Histogram must have at least one bucket');
@@ -395,7 +397,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldThrowAnExceptionWhenThereIsALabelNamedLe()
+    public function itShouldThrowAnExceptionWhenThereIsALabelNamedLe(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Histogram cannot have a label named');
@@ -405,7 +407,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldRejectInvalidMetricsNames()
+    public function itShouldRejectInvalidMetricsNames(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid metric name');
@@ -415,7 +417,7 @@ abstract class AbstractHistogramTest extends TestCase
     /**
      * @test
      */
-    public function itShouldRejectInvalidLabelNames()
+    public function itShouldRejectInvalidLabelNames(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid label name');
@@ -428,34 +430,35 @@ abstract class AbstractHistogramTest extends TestCase
      *
      * @param mixed $value The label value
      */
-    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value)
+    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value): void
     {
         $label = 'foo';
         $histogram = new Histogram($this->adapter, 'test', 'some_metric', 'help', [$label], [1]);
         $histogram->observe(1, [$value]);
 
         $metrics = $this->adapter->collect();
-        $this->assertIsArray($metrics);
-        $this->assertCount(1, $metrics);
-        $this->assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
+        self::assertCount(1, $metrics);
+        self::assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
 
         $metric = reset($metrics);
+        self::assertInstanceOf(MetricFamilySamples::class, $metric);
         $samples = $metric->getSamples();
-        $this->assertContainsOnlyInstancesOf(Sample::class, $samples);
+        self::assertContainsOnlyInstancesOf(Sample::class, $samples);
 
         foreach ($samples as $sample) {
             $labels = array_combine(
                 array_merge($metric->getLabelNames(), $sample->getLabelNames()),
                 $sample->getLabelValues()
             );
-            $this->assertEquals($value, $labels[$label]);
+            self::assertIsArray($labels);
+            self::assertEquals($value, $labels[$label]);
         }
     }
 
     /**
      * @test
      */
-    public function itShouldBeAbleToGenerateExponentialBucketsGivenSpecificBounds()
+    public function itShouldBeAbleToGenerateExponentialBucketsGivenSpecificBounds(): void
     {
         $start = 0.05;
         $growthFactor = 1.5;
@@ -480,14 +483,14 @@ abstract class AbstractHistogramTest extends TestCase
             9.7309753417969,
         ];
 
-        $this->assertEquals($generatedBuckets, $expectedBuckets);
+        self::assertEquals($generatedBuckets, $expectedBuckets);
     }
 
     /**
-     * @return array
+     * @return mixed[]
      * @see isShouldAcceptArbitraryLabelValues
      */
-    public function labelValuesDataProvider()
+    public function labelValuesDataProvider(): array
     {
         $cases = [];
         // Basic Latin

--- a/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\InMemory;
 
 use Prometheus\Storage\InMemory;
@@ -7,7 +9,7 @@ use Test\Prometheus\AbstractCollectorRegistryTest;
 
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
         $this->adapter->flushMemory();

--- a/tests/Test/Prometheus/InMemory/CounterTest.php
+++ b/tests/Test/Prometheus/InMemory/CounterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\InMemory;
 
 use Prometheus\Storage\InMemory;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractCounterTest;
 class CounterTest extends AbstractCounterTest
 {
 
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
         $this->adapter->flushMemory();

--- a/tests/Test/Prometheus/InMemory/GaugeTest.php
+++ b/tests/Test/Prometheus/InMemory/GaugeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\InMemory;
 
 use Prometheus\Storage\InMemory;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractGaugeTest;
 class GaugeTest extends AbstractGaugeTest
 {
 
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
         $this->adapter->flushMemory();

--- a/tests/Test/Prometheus/InMemory/HistogramTest.php
+++ b/tests/Test/Prometheus/InMemory/HistogramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\InMemory;
 
 use Prometheus\Storage\InMemory;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractHistogramTest;
 class HistogramTest extends AbstractHistogramTest
 {
 
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
         $this->adapter->flushMemory();

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\Redis;
 
 use Prometheus\Storage\Redis;
@@ -10,7 +12,7 @@ use Test\Prometheus\AbstractCollectorRegistryTest;
  */
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
         $this->adapter->flushRedis();

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\Redis;
 
 use Prometheus\Storage\Redis;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractCounterTest;
  */
 class CounterTest extends AbstractCounterTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
         $this->adapter->flushRedis();

--- a/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\Redis;
 
 use Prometheus\Storage\Redis;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractCounterTest;
  */
 class CounterWithPrefixTest extends AbstractCounterTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\Redis;
 
 use Prometheus\Storage\Redis;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractGaugeTest;
  */
 class GaugeTest extends AbstractGaugeTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
         $this->adapter->flushRedis();

--- a/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\Redis;
 
 use Prometheus\Storage\Redis;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractGaugeTest;
  */
 class GaugeWithPrefixTest extends AbstractGaugeTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\Redis;
 
 use Prometheus\Storage\Redis;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractHistogramTest;
  */
 class HistogramTest extends AbstractHistogramTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
         $this->adapter->flushRedis();

--- a/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Test\Prometheus\Redis;
 
 use Prometheus\Storage\Redis;
@@ -11,7 +13,7 @@ use Test\Prometheus\AbstractHistogramTest;
  */
 class HistogramWithPrefixTest extends AbstractHistogramTest
 {
-    public function configureAdapter()
+    public function configureAdapter(): void
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);

--- a/tests/Test/Prometheus/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/RenderTextFormatTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus;
+
+use Prometheus\CollectorRegistry;
+use Prometheus\Exception\MetricsRegistrationException;
+use Prometheus\MetricFamilySamples;
+use Prometheus\RenderTextFormat;
+use PHPUnit\Framework\TestCase;
+use Prometheus\Storage\InMemory;
+
+class RenderTextFormatTest extends TestCase
+{
+
+    public function testOutputMatchesExpectations(): void
+    {
+        $metrics = $this->buildSamples();
+
+        $renderer = new RenderTextFormat();
+        $output = $renderer->render($metrics);
+
+        self::assertSame($this->getExpectedOutput(), $output);
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     * @throws MetricsRegistrationException
+     */
+    private function buildSamples(): array
+    {
+        $namespace = 'mynamespace';
+        $registry = new CollectorRegistry(new InMemory(), false);
+        $registry->getOrRegisterCounter($namespace, 'counter', 'counter-help-text', ['label1', 'label2'])
+                 ->inc(['bob', 'al\ice']);
+        $registry->getOrRegisterGauge($namespace, 'gauge', 'counter-help-text', ['label1', 'label2'])
+                 ->inc(["bo\nb", 'ali\"ce']);
+        $registry->getOrRegisterHistogram($namespace, 'histogram', 'counter-help-text', ['label1', 'label2'], [0, 10, 100])
+                 ->observe(5, ['bob', 'alice']);
+
+        return $registry->getMetricFamilySamples();
+    }
+
+    private function getExpectedOutput(): string
+    {
+        return <<<TEXTPLAIN
+# HELP mynamespace_counter counter-help-text
+# TYPE mynamespace_counter counter
+mynamespace_counter{label1="bob",label2="al\\\\ice"} 1
+# HELP mynamespace_gauge counter-help-text
+# TYPE mynamespace_gauge gauge
+mynamespace_gauge{label1="bo\\nb",label2="ali\\\\\"ce"} 1
+# HELP mynamespace_histogram counter-help-text
+# TYPE mynamespace_histogram histogram
+mynamespace_histogram_bucket{label1="bob",label2="alice",le="0"} 0
+mynamespace_histogram_bucket{label1="bob",label2="alice",le="10"} 1
+mynamespace_histogram_bucket{label1="bob",label2="alice",le="100"} 1
+mynamespace_histogram_bucket{label1="bob",label2="alice",le="+Inf"} 1
+mynamespace_histogram_count{label1="bob",label2="alice"} 1
+mynamespace_histogram_sum{label1="bob",label2="alice"} 5
+
+TEXTPLAIN;
+    }
+}

--- a/tests/Test/Prometheus/Storage/RedisTest.php
+++ b/tests/Test/Prometheus/Storage/RedisTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Prometheus\Storage;
 
 use PHPUnit\Framework\TestCase;
@@ -13,7 +15,7 @@ class RedisTest extends TestCase
     /**
      * @test
      */
-    public function itShouldThrowAnExceptionOnConnectionFailure()
+    public function itShouldThrowAnExceptionOnConnectionFailure(): void
     {
         $redis = new Redis(['host' => '/dev/null']);
 
@@ -27,7 +29,7 @@ class RedisTest extends TestCase
     /**
      * @test
      */
-    public function itShouldThrowExceptionWhenInjectedRedisIsNotConnected()
+    public function itShouldThrowExceptionWhenInjectedRedisIsNotConnected(): void
     {
         $connection = new \Redis();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 error_reporting(-1);
 date_default_timezone_set('UTC');
 $autoload = __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
- [x] Install PHPStan with level 8 and plugins
- [x] Address initial issues in `src` and `tests`

Ok, this solves all main type issues and a couple of small issues here and there that PHPstorm was eager to fix also.

Let's look it over carefully, but all tests are good. I saw some other small issues along the way, I'll try to give some time to that also, and make a few suggestions to tighten everything together.

I updated the actions to separate checks from tests to get contributors early results.