### PR TITLE
Allow incrementing counters with floats

### DIFF
--- a/src/Prometheus/Counter.php
+++ b/src/Prometheus/Counter.php
@@ -27,10 +27,10 @@ class Counter extends Collector
     }
 
     /**
-     * @param int $count e.g. 2
+     * @param int|float $count e.g. 2
      * @param mixed[] $labels e.g. ['status', 'opcode']
      */
-    public function incBy(int $count, array $labels = []): void
+    public function incBy($count, array $labels = []): void
     {
         $this->assertLabelsAreDefinedCorrectly($labels);
 
@@ -42,7 +42,7 @@ class Counter extends Collector
                 'labelNames' => $this->getLabelNames(),
                 'labelValues' => $labels,
                 'value' => $count,
-                'command' => Adapter::COMMAND_INCREMENT_INTEGER,
+                'command' => is_float($count) ? Adapter::COMMAND_INCREMENT_FLOAT : Adapter::COMMAND_INCREMENT_INTEGER,
             ]
         );
     }

--- a/tests/Test/Prometheus/AbstractCounterTest.php
+++ b/tests/Test/Prometheus/AbstractCounterTest.php
@@ -130,6 +130,40 @@ abstract class AbstractCounterTest extends TestCase
     /**
      * @test
      */
+    public function itShouldIncreaseTheCounterWithAFloat(): void
+    {
+        $counter = new Counter($this->adapter, 'test', 'some_metric', 'this is for testing', ['foo', 'bar']);
+        $counter->inc(['lalal', 'lululu']);
+        $counter->incBy(1.5, ['lalal', 'lululu']);
+        self::assertThat(
+            $this->adapter->collect(),
+            self::equalTo(
+                [
+                    new MetricFamilySamples(
+                        [
+                            'type' => Counter::TYPE,
+                            'help' => 'this is for testing',
+                            'name' => 'test_some_metric',
+                            'labelNames' => ['foo', 'bar'],
+                            'samples' => [
+                                [
+                                    'labelValues' => ['lalal', 'lululu'],
+                                    'value' => 2.5,
+                                    'name' => 'test_some_metric',
+                                    'labelNames' => [],
+                                ],
+                            ],
+                        ]
+                    ),
+                ]
+            )
+        );
+    }
+
+
+    /**
+     * @test
+     */
     public function itShouldRejectInvalidMetricsNames(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
This allows incrementing counters with floats. 

For this, we need to change the storing logic within the `APCuStorage`, which used `apcu_inc` before and now uses the same way as we have it for gauges. We should refactor this a bit in the future.

Additionally, we need to set the Redis storage command based on what the type of the value is with that we want to increment, otherwise, it won't increment and fail "silently".
https://github.com/PromPHP/prometheus_client_php/pull/22/files#diff-e8fd41f0e9039fc21760030aeae90caae1f76729cac8d15cdb3a96df34c37454R45


Closes #20 