### PR TITLE
Throw StorageException in APC when apc-ext is missing or disabled

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -5,12 +5,28 @@ declare(strict_types=1);
 namespace Prometheus\Storage;
 
 use APCUIterator;
+use Prometheus\Exception\StorageException;
 use Prometheus\MetricFamilySamples;
 use RuntimeException;
 
 class APC implements Adapter
 {
     const PROMETHEUS_PREFIX = 'prom';
+
+    /**
+     * APC constructor.
+     *
+     * @throws StorageException
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('apcu')) {
+            throw new StorageException('APCu extension is not loaded');
+        }
+        if (!apcu_enabled()) {
+            throw new StorageException('APCu is not enabled');
+        }
+    }
 
     /**
      * @return MetricFamilySamples[]


### PR DESCRIPTION
Fixes #27 

Just two simple checks on conditions which prevents APC Adapter to work properly.

