### PR TITLE
On flush remove only prometheus specific keys from APCu

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -109,11 +109,21 @@ class APC implements Adapter
     }
 
     /**
+     * Removes all previously stored data from apcu
+     *
      * @return void
      */
     public function flushAPC(): void
     {
-        apcu_clear_cache();
+        //                   /      / | PCRE expresion boundary
+        //                    ^       | match from first character only
+        //                     %s:    | common prefix substitute with colon suffix
+        //                        .+  | at least one additional character
+        $matchAll = sprintf('/^%s:.+/', self::PROMETHEUS_PREFIX);
+
+        foreach (new APCUIterator($matchAll) as $key => $value) {
+            apcu_delete($key);
+        }
     }
 
     /**

--- a/tests/Test/Prometheus/Storage/APCTest.php
+++ b/tests/Test/Prometheus/Storage/APCTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prometheus\Storage;
+
+use APCuIterator;
+use PHPUnit\Framework\TestCase;
+use Prometheus\CollectorRegistry;
+
+/**
+ * @requires extension apcu
+ */
+class APCTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function itShouldNotClearWholeAPCacheOnFlush(): void
+    {
+        apcu_clear_cache();
+        apcu_add("not a prometheus metric key", "data");
+
+        $apc      = new APC();
+        $registry = new CollectorRegistry($apc);
+        $registry->getOrRegisterCounter("namespace", "counter", "counter help")->inc();
+        $registry->getOrRegisterGauge("namespace", "gauge", "gauge help")->inc();
+        $registry->getOrRegisterHistogram("namespace", "histogram", "histogram help")->observe(1);
+        $apc->flushAPC();
+
+        $cacheEntries = iterator_to_array(new APCuIterator(null), true);
+        $cacheMap     = array_map(function ($item) {
+            return $item['value'];
+        }, $cacheEntries);
+
+        self::assertThat(
+            $cacheMap,
+            self::equalTo([
+                'not a prometheus metric key' => 'data',
+            ])
+        );
+    }
+}


### PR DESCRIPTION
I believe that no library should flush entire apcu.