### PR TITLE
On flush remove only prometheus specific keys from redis

### DIFF
--- a/examples/flush_adapter.php
+++ b/examples/flush_adapter.php
@@ -2,17 +2,18 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$adapter = $_GET['adapter'];
+$adapterName = $_GET['adapter'];
 
-if ($adapter === 'redis') {
+$adapter = null;
+
+if ($adapterName === 'redis') {
     define('REDIS_HOST', $_SERVER['REDIS_HOST'] ?? '127.0.0.1');
 
-    $redisAdapter = new Prometheus\Storage\Redis(['host' => REDIS_HOST]);
-    $redisAdapter->flushRedis();
-} elseif ($adapter === 'apc') {
-    $apcAdapter = new Prometheus\Storage\APC();
-    $apcAdapter->flushAPC();
-} elseif ($adapter === 'in-memory') {
-    $inMemoryAdapter = new Prometheus\Storage\InMemory();
-    $inMemoryAdapter->flushMemory();
+    $adapter = new Prometheus\Storage\Redis(['host' => REDIS_HOST]);
+} elseif ($adapterName === 'apc') {
+    $adapter = new Prometheus\Storage\APC();
+} elseif ($adapterName === 'in-memory') {
+    $adapter = new Prometheus\Storage\InMemory();
 }
+
+$adapter->wipeStorage();

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -125,11 +125,21 @@ class APC implements Adapter
     }
 
     /**
-     * Removes all previously stored data from apcu
+     * @deprecated use replacement method wipeStorage from Adapter interface
      *
      * @return void
      */
     public function flushAPC(): void
+    {
+        $this->wipeStorage();
+    }
+
+    /**
+     * Removes all previously stored data from apcu
+     *
+     * @return void
+     */
+    public function wipeStorage(): void
     {
         //                   /      / | PCRE expresion boundary
         //                    ^       | match from first character only

--- a/src/Prometheus/Storage/Adapter.php
+++ b/src/Prometheus/Storage/Adapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Prometheus\Storage;
 
+use Prometheus\Exception\StorageException;
 use Prometheus\MetricFamilySamples;
 
 interface Adapter
@@ -34,4 +35,12 @@ interface Adapter
      * @return void
      */
     public function updateCounter(array $data): void;
+
+    /**
+     * Removes all previously stored metrics from underlying storage
+     *
+     * @throws StorageException
+     * @return void
+     */
+    public function wipeStorage(): void;
 }

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -36,7 +36,18 @@ class InMemory implements Adapter
         return $metrics;
     }
 
+    /**
+     * @deprecated use replacement method wipeStorage from Adapter interface
+     */
     public function flushMemory(): void
+    {
+        $this->wipeStorage();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function wipeStorage(): void
     {
         $this->counters = [];
         $this->gauges = [];

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -92,17 +92,25 @@ class Redis implements Adapter
     }
 
     /**
-     * Atomically removes all previously stored data from redis
-     *
+     * @deprecated use replacement method wipeStorage from Adapter interface
      * @throws StorageException
      */
     public function flushRedis(): void
+    {
+        $this->wipeStorage();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function wipeStorage(): void
     {
         $this->ensureOpenConnection();
 
         $searchPattern = "";
 
         $globalPrefix = $this->redis->getOption(\Redis::OPT_PREFIX);
+        // @phpstan-ignore-next-line false positive, phpstan thinks getOptions returns int
         if (is_string($globalPrefix)) {
             $searchPattern .= $globalPrefix;
         }

--- a/tests/Test/Prometheus/APC/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APC/CollectorRegistryTest.php
@@ -16,6 +16,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter(): void
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/APC/CounterTest.php
+++ b/tests/Test/Prometheus/APC/CounterTest.php
@@ -16,6 +16,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter(): void
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/APC/GaugeTest.php
+++ b/tests/Test/Prometheus/APC/GaugeTest.php
@@ -16,6 +16,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter(): void
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/APC/HistogramTest.php
+++ b/tests/Test/Prometheus/APC/HistogramTest.php
@@ -16,6 +16,6 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter(): void
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
@@ -12,6 +12,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/InMemory/CounterTest.php
+++ b/tests/Test/Prometheus/InMemory/CounterTest.php
@@ -16,6 +16,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/InMemory/GaugeTest.php
+++ b/tests/Test/Prometheus/InMemory/GaugeTest.php
@@ -16,6 +16,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/InMemory/HistogramTest.php
+++ b/tests/Test/Prometheus/InMemory/HistogramTest.php
@@ -16,6 +16,6 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter(): void
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -14,7 +14,10 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
     public function configureAdapter(): void
     {
-        $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $connection = new \Redis();
+        $connection->connect(REDIS_HOST);
+        $connection->flushAll();
+
+        $this->adapter = Redis::fromExistingConnection($connection);
     }
 }

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -14,10 +14,7 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
     public function configureAdapter(): void
     {
-        $connection = new \Redis();
-        $connection->connect(REDIS_HOST);
-        $connection->flushAll();
-
-        $this->adapter = Redis::fromExistingConnection($connection);
+        $this->adapter = new Redis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -15,7 +15,10 @@ class CounterTest extends AbstractCounterTest
 {
     public function configureAdapter(): void
     {
-        $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $connection = new \Redis();
+        $connection->connect(REDIS_HOST);
+        $connection->flushAll();
+
+        $this->adapter = Redis::fromExistingConnection($connection);
     }
 }

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -15,10 +15,7 @@ class CounterTest extends AbstractCounterTest
 {
     public function configureAdapter(): void
     {
-        $connection = new \Redis();
-        $connection->connect(REDIS_HOST);
-        $connection->flushAll();
-
-        $this->adapter = Redis::fromExistingConnection($connection);
+        $this->adapter = new Redis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
@@ -17,10 +17,10 @@ class CounterWithPrefixTest extends AbstractCounterTest
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);
+        $connection->flushAll();
 
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
-        $this->adapter->flushRedis();
     }
 }

--- a/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
@@ -17,10 +17,10 @@ class CounterWithPrefixTest extends AbstractCounterTest
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);
-        $connection->flushAll();
 
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -15,7 +15,10 @@ class GaugeTest extends AbstractGaugeTest
 {
     public function configureAdapter(): void
     {
-        $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $connection = new \Redis();
+        $connection->connect(REDIS_HOST);
+        $connection->flushAll();
+
+        $this->adapter = Redis::fromExistingConnection($connection);
     }
 }

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -15,10 +15,7 @@ class GaugeTest extends AbstractGaugeTest
 {
     public function configureAdapter(): void
     {
-        $connection = new \Redis();
-        $connection->connect(REDIS_HOST);
-        $connection->flushAll();
-
-        $this->adapter = Redis::fromExistingConnection($connection);
+        $this->adapter = new Redis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
@@ -17,10 +17,10 @@ class GaugeWithPrefixTest extends AbstractGaugeTest
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);
+        $connection->flushAll();
 
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
-        $this->adapter->flushRedis();
     }
 }

--- a/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
@@ -17,10 +17,10 @@ class GaugeWithPrefixTest extends AbstractGaugeTest
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);
-        $connection->flushAll();
 
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -15,10 +15,7 @@ class HistogramTest extends AbstractHistogramTest
 {
     public function configureAdapter(): void
     {
-        $connection = new \Redis();
-        $connection->connect(REDIS_HOST);
-        $connection->flushAll();
-
-        $this->adapter = Redis::fromExistingConnection($connection);
+        $this->adapter = new Redis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -15,7 +15,10 @@ class HistogramTest extends AbstractHistogramTest
 {
     public function configureAdapter(): void
     {
-        $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $connection = new \Redis();
+        $connection->connect(REDIS_HOST);
+        $connection->flushAll();
+
+        $this->adapter = Redis::fromExistingConnection($connection);
     }
 }

--- a/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
@@ -17,10 +17,10 @@ class HistogramWithPrefixTest extends AbstractHistogramTest
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);
+        $connection->flushAll();
 
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
-        $this->adapter->flushRedis();
     }
 }

--- a/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
@@ -17,10 +17,10 @@ class HistogramWithPrefixTest extends AbstractHistogramTest
     {
         $connection = new \Redis();
         $connection->connect(REDIS_HOST);
-        $connection->flushAll();
 
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
+        $this->adapter->wipeStorage();
     }
 }

--- a/tests/Test/Prometheus/Storage/APCTest.php
+++ b/tests/Test/Prometheus/Storage/APCTest.php
@@ -27,7 +27,7 @@ class APCTest extends TestCase
         $registry->getOrRegisterCounter("namespace", "counter", "counter help")->inc();
         $registry->getOrRegisterGauge("namespace", "gauge", "gauge help")->inc();
         $registry->getOrRegisterHistogram("namespace", "histogram", "histogram help")->observe(1);
-        $apc->flushAPC();
+        $apc->wipeStorage();
 
         $cacheEntries = iterator_to_array(new APCuIterator(null), true);
         $cacheMap     = array_map(function ($item) {

--- a/tests/Test/Prometheus/Storage/RedisTest.php
+++ b/tests/Test/Prometheus/Storage/RedisTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prometheus\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Prometheus\CollectorRegistry;
 use Prometheus\Exception\StorageException;
 
 /**
@@ -12,6 +13,19 @@ use Prometheus\Exception\StorageException;
  */
 class RedisTest extends TestCase
 {
+
+    /**
+     * @var \Redis
+     */
+    private $redisConnection;
+
+    protected function setUp(): void
+    {
+        $this->redisConnection = new \Redis();
+        $this->redisConnection->connect(REDIS_HOST);
+        $this->redisConnection->flushAll();
+    }
+
     /**
      * @test
      */
@@ -37,5 +51,32 @@ class RedisTest extends TestCase
         $this->expectExceptionMessage('Connection to Redis server not established');
 
         Redis::fromExistingConnection($connection);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotClearWholeRedisOnFlush(): void
+    {
+        $this->redisConnection->set('not a prometheus metric key', 'data');
+
+        $redis    = Redis::fromExistingConnection($this->redisConnection);
+        $registry = new CollectorRegistry($redis);
+
+        // ensure flush is working correctly on large number of metrics
+        for ($i = 0; $i < 1000; $i++) {
+            $registry->getOrRegisterCounter('namespace', "counter_$i", 'counter help')->inc();
+            $registry->getOrRegisterGauge('namespace', "gauge_$i", 'gauge help')->inc();
+            $registry->getOrRegisterHistogram('namespace', "histogram_$i", 'histogram help')->observe(1);
+        }
+        $redis->flushRedis();
+
+        $redisKeys = $this->redisConnection->keys("*");
+        self::assertThat(
+            $redisKeys,
+            self::equalTo([
+                'not a prometheus metric key'
+            ])
+        );
     }
 }

--- a/tests/Test/Prometheus/Storage/RedisTest.php
+++ b/tests/Test/Prometheus/Storage/RedisTest.php
@@ -37,7 +37,7 @@ class RedisTest extends TestCase
         $this->expectExceptionMessage("Can't connect to Redis server");
 
         $redis->collect();
-        $redis->flushRedis();
+        $redis->wipeStorage();
     }
 
     /**
@@ -69,7 +69,7 @@ class RedisTest extends TestCase
             $registry->getOrRegisterGauge('namespace', "gauge_$i", 'gauge help')->inc();
             $registry->getOrRegisterHistogram('namespace', "histogram_$i", 'histogram help')->observe(1);
         }
-        $redis->flushRedis();
+        $redis->wipeStorage();
 
         $redisKeys = $this->redisConnection->keys("*");
         self::assertThat(


### PR DESCRIPTION
I am reasonably sure this change will don't break anyone's code.

In our company workflow flushing entire redis ( all databases ) when cleaning up stale metrics, would be really nasty surprise.

When i was changing test setup code, it dawned on me that those flush* methods  wasn't probably meant for public API at all.

In the event of not accepting this PR, i humbly suggest changing the flushing mechanism from flushAll to flushDB, limiting the potential blast radius.