### PR TITLE
Fix PHPStan error introduced with latest phpstan release

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -335,19 +335,35 @@ class APC implements Adapter
     /**
      * @param mixed $val
      * @return int
+     * @throws RuntimeException
      */
     private function toBinaryRepresentationAsInteger($val): int
     {
-        return unpack('Q', pack('d', $val))[1];
+        $packedDouble = pack('d', $val);
+        if ((bool)$packedDouble !== false) {
+            $unpackedData = unpack("Q", $packedDouble);
+            if (is_array($unpackedData)) {
+                return $unpackedData[1];
+            }
+        }
+        throw new RuntimeException("Formatting from binary representation to integer did not work");
     }
 
     /**
      * @param mixed $val
      * @return float
+     * @throws RuntimeException
      */
     private function fromBinaryRepresentationAsInteger($val): float
     {
-        return unpack('d', pack('Q', $val))[1];
+        $packedBinary = pack('Q', $val);
+        if ((bool)$packedBinary !== false) {
+            $unpackedData = unpack("d", $packedBinary);
+            if (is_array($unpackedData)) {
+                return $unpackedData[1];
+            }
+        }
+        throw new RuntimeException("Formatting from integer to binary representation did not work");
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

This fixes the error reported from phpstan:
```
 ------ ---------------------------------------- 
  Line   src/Prometheus/Storage/APC.php          
 ------ ---------------------------------------- 
  351    Cannot access offset 1 on array|false.  
  360    Cannot access offset 1 on array|false.  
 ------ ---------------------------------------- 
 ```
 
 The change is quite expensive because the PHP doc on these functions is kind of broken (it returns array|false, but should be array|bool). Therefore I need to cast the result to a bool and check then if it is false. I added a RuntimeException that is thrown in case of an impossible unpacking/packing.