### PR TITLE
Tree-based APC storage engine

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -141,7 +141,7 @@ class APC implements Adapter
     }
 
     /**
-     * @param array $metaData
+     * @param array<string> $metaData
      * @param string $labels
      * @return string
      */
@@ -153,7 +153,7 @@ class APC implements Adapter
     /**
      * Store ':label' keys for each metric's labelName in APC.
      *
-     * @param array $data
+     * @param array<mixed> $data
      * @return void
      */
     private function storeLabelKeys(array $data): void
@@ -184,7 +184,7 @@ class APC implements Adapter
         if (false === $arr) {
             $arr = [];
         }
-        if (in_array($item, $arr)) {
+        if (in_array($item, $arr, true)) {
             return;
         }
         $arr[] = $item;
@@ -300,12 +300,15 @@ class APC implements Adapter
      *  [9] => ['/private', 'get', 'fail'], [10] => ['/private', 'post', 'success'], [11] => ['/private', 'post', 'fail'],
      *  [12] => ['/metrics', 'put', 'success'], [13] => ['/metrics', 'put', 'fail'], [14] => ['/metrics', 'get', 'success'],
      *  [15] => ['/metrics', 'get', 'fail'], [16] => ['/metrics', 'post', 'success'], [17] => ['/metrics', 'post', 'fail']
-     * @return array
+     * @param array<string> $labelNames
+     * @param array<array> $labelValues
+     * @return array<array>
      */
     private function buildPermutationTree(array $labelNames, array $labelValues): array
     {
         $treeRowCount = count(array_keys($labelNames));
         $numElements = 1;
+        $treeInfo = [];
         for ($i = $treeRowCount - 1; $i >= 0; $i--) {
             $treeInfo[$i]['numInRow'] = count($labelValues[$i]);
             $numElements *= $treeInfo[$i]['numInRow'];
@@ -361,7 +364,7 @@ class APC implements Adapter
      * When given a type ('histogram', 'gauge', or 'counter'), return an iterable array of matching records retrieved from APCu
      *
      * @param string $type
-     * @return array
+     * @return array<array>
      */
     private function getMetas(string $type) : array
     {
@@ -369,7 +372,7 @@ class APC implements Adapter
         $root = apcu_fetch($this->rootNode());
         if (is_array($root)) {
             foreach ($root as $metaKey) {
-                if (preg_match('/' . self::PROMETHEUS_PREFIX . ':' . $type . ':.*:meta/', $metaKey) && false !== ($gauge = apcu_fetch($metaKey))) {
+                if ((1 === preg_match('/' . self::PROMETHEUS_PREFIX . ':' . $type . ':.*:meta/', $metaKey)) && false !== ($gauge = apcu_fetch($metaKey))) {
                     $arr[] = [ 'key' => $metaKey, 'value' => $gauge ];
                 }
             }
@@ -381,8 +384,8 @@ class APC implements Adapter
      * When given a type ('histogram', 'gauge', or 'counter') and metaData array, return an iterable array of matching records retrieved from APCu
      *
      * @param string $type
-     * @param array $metaData
-     * @return array
+     * @param array<mixed> $metaData
+     * @return array<array>
      */
     private function getValues(string $type, array $metaData) : array
     {

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -147,7 +147,7 @@ class APC implements Adapter
      */
     private function assembleLabelKey(array $metaData, string $labels): string
     {
-        return implode(':', [ self::PROMETHEUS_PREFIX, $metaData['type'], $metaData['name'], $labels, 'label' ] );
+        return implode(':', [ self::PROMETHEUS_PREFIX, $metaData['type'], $metaData['name'], $labels, 'label' ]);
     }
 
     /**
@@ -366,7 +366,7 @@ class APC implements Adapter
      * @param string $type
      * @return array<array>
      */
-    private function getMetas(string $type) : array
+    private function getMetas(string $type): array
     {
         $arr = [];
         $root = apcu_fetch($this->rootNode());
@@ -387,7 +387,7 @@ class APC implements Adapter
      * @param array<mixed> $metaData
      * @return array<array>
      */
-    private function getValues(string $type, array $metaData) : array
+    private function getValues(string $type, array $metaData): array
     {
         $labels = $arr = [];
         foreach (array_values($metaData['labelNames']) as $label) {


### PR DESCRIPTION
Initial pass at implementing the directed acyclic graph as described in #36 .  This code also contains an upper-bound on how many failed calls to `apcu_cas()` in a tight loop will be allowed before an exception is thrown, to prevent an infinite loop arising from some unforeseen APCu misbehavior.  I'm not strongly attached to this loop-catcher for the general case if anybody is opposed, but for my needs it was deemed important to have, as a defensive-coding pattern.

The DAG is a tree structure, starting with a root node, which contains a serialized array of all the metadata keys stored in APCu.  Each metadata key contains a collection of the typical metadata (name, help, metric type) as well as an array of labelNames associated with the metric being measured, and if the metric is a histogram then an array of buckets.  The metadata APCu key names end with ":meta".

For each labelNames item, a ":label" APCu key is created, listing all labels for each labelName.  Then for each permutation of labels, a ":value" APCu key is created _once the label-tuple contains a value_.  Similarly, for each histogram bucket assigned to a label-tuple, a bucket-specific ":value" APCu key is created _once the bucket contains a value_.  This also applies for the special buckets "sum" and "+Inf", which are not stored as part of the metadata APCu key for the metric.

The described structure allows all APCu keys containing values to be quickly enumerated, simply by reading the root node, loading each metadata APCu key referenced by the root node, and programmatically generating every ":label" and ":value" APCu key that could exist based on the contents of that metadata key.  Wiping all data follows a similar pattern: enumerate all keys which contain data and delete them, starting at the leaf nodes and working backward toward the root, deleting the root node last of all.

Note there is a small race condition in `addItemToKey()`, between reading the array and writing it back, another thread could add an element to the contents of the key. For my purposes this is acceptable, because if a metadata pointer gets deleted from the root node, for instance, the next thread to write to that metric will re-create the missing array pointer and will likely succeed.  When hundreds of threads per second are writing metrics, the window where this pointer is missing will be exceedingly small -- and when traffic is light, chances are good that this race condition will not be triggered.  However, it could be improved -- I'm still thinking about ways to serialize access to the critical part of that function -- ideas are welcome!