### PR TITLE
Add methods to validate Metric Names & Labels Keys

### DIFF
--- a/src/Prometheus/Collector.php
+++ b/src/Prometheus/Collector.php
@@ -42,11 +42,11 @@ abstract class Collector
     {
         $this->storageAdapter = $storageAdapter;
         $metricName = ($namespace !== '' ? $namespace . '_' : '') . $name;
-        self::validateMetricName($metricName);
+        self::assertValidMetricName($metricName);
         $this->name = $metricName;
         $this->help = $help;
         foreach ($labels as $label) {
-            self::validateLabel($label);
+            self::assertValidLabel($label);
         }
         $this->labels = $labels;
     }
@@ -101,7 +101,7 @@ abstract class Collector
     /**
      * @param string $metricName
      */
-    public static function validateMetricName(string $metricName): void
+    public static function assertValidMetricName(string $metricName): void
     {
         if (preg_match(self::RE_METRIC_LABEL_NAME, $metricName) !== 1) {
             throw new InvalidArgumentException("Invalid metric name: '" . $metricName . "'");
@@ -111,7 +111,7 @@ abstract class Collector
     /**
      * @param string $label
      */
-    public static function validateLabel(string $label): void
+    public static function assertValidLabel(string $label): void
     {
         if (preg_match(self::RE_METRIC_LABEL_NAME, $label) !== 1) {
             throw new InvalidArgumentException("Invalid label name: '" . $label . "'");

--- a/src/Prometheus/Collector.php
+++ b/src/Prometheus/Collector.php
@@ -33,24 +33,20 @@ abstract class Collector
 
     /**
      * @param Adapter $storageAdapter
-     * @param string  $namespace
-     * @param string  $name
-     * @param string  $help
-     * @param string[]   $labels
+     * @param string $namespace
+     * @param string $name
+     * @param string $help
+     * @param string[] $labels
      */
     public function __construct(Adapter $storageAdapter, string $namespace, string $name, string $help, array $labels = [])
     {
         $this->storageAdapter = $storageAdapter;
         $metricName = ($namespace !== '' ? $namespace . '_' : '') . $name;
-        if (preg_match(self::RE_METRIC_LABEL_NAME, $metricName) !== 1) {
-            throw new InvalidArgumentException("Invalid metric name: '" . $metricName . "'");
-        }
+        self::validateMetricName($metricName);
         $this->name = $metricName;
         $this->help = $help;
         foreach ($labels as $label) {
-            if (preg_match(self::RE_METRIC_LABEL_NAME, $label) !== 1) {
-                throw new InvalidArgumentException("Invalid label name: '" . $label . "'");
-            }
+            self::validateLabel($label);
         }
         $this->labels = $labels;
     }
@@ -99,6 +95,26 @@ abstract class Collector
     {
         if (count($labels) !== count($this->labels)) {
             throw new InvalidArgumentException(sprintf('Labels are not defined correctly: %s', print_r($labels, true)));
+        }
+    }
+
+    /**
+     * @param string $metricName
+     */
+    public static function validateMetricName(string $metricName): void
+    {
+        if (preg_match(self::RE_METRIC_LABEL_NAME, $metricName) !== 1) {
+            throw new InvalidArgumentException("Invalid metric name: '" . $metricName . "'");
+        }
+    }
+
+    /**
+     * @param string $label
+     */
+    public static function validateLabel(string $label): void
+    {
+        if (preg_match(self::RE_METRIC_LABEL_NAME, $label) !== 1) {
+            throw new InvalidArgumentException("Invalid label name: '" . $label . "'");
         }
     }
 }

--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -45,7 +45,7 @@ class CollectorRegistry implements RegistryInterface
      * CollectorRegistry constructor.
      *
      * @param Adapter $storageAdapter
-     * @param bool    $registerDefaultMetrics
+     * @param bool $registerDefaultMetrics
      */
     public function __construct(Adapter $storageAdapter, bool $registerDefaultMetrics = true)
     {
@@ -72,9 +72,9 @@ class CollectorRegistry implements RegistryInterface
     }
 
     /**
-     * @param string   $namespace e.g. cms
-     * @param string   $name e.g. duration_seconds
-     * @param string   $help e.g. The duration something took in seconds.
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
      * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Gauge
@@ -106,16 +106,16 @@ class CollectorRegistry implements RegistryInterface
     public function getGauge(string $namespace, string $name): Gauge
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
-        if (! isset($this->gauges[$metricIdentifier])) {
+        if (!isset($this->gauges[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
         return $this->gauges[$metricIdentifier];
     }
 
     /**
-     * @param string   $namespace e.g. cms
-     * @param string   $name e.g. duration_seconds
-     * @param string   $help e.g. The duration something took in seconds.
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
      * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Gauge
@@ -132,9 +132,9 @@ class CollectorRegistry implements RegistryInterface
     }
 
     /**
-     * @param string   $namespace e.g. cms
-     * @param string   $name e.g. requests
-     * @param string   $help e.g. The number of requests made.
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
      * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Counter
@@ -166,16 +166,16 @@ class CollectorRegistry implements RegistryInterface
     public function getCounter(string $namespace, string $name): Counter
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
-        if (! isset($this->counters[$metricIdentifier])) {
+        if (!isset($this->counters[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
         return $this->counters[self::metricIdentifier($namespace, $name)];
     }
 
     /**
-     * @param string   $namespace e.g. cms
-     * @param string   $name e.g. requests
-     * @param string   $help e.g. The number of requests made.
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
      * @param string[] $labels e.g. ['controller', 'action']
      *
      * @return Counter
@@ -192,10 +192,10 @@ class CollectorRegistry implements RegistryInterface
     }
 
     /**
-     * @param string     $namespace e.g. cms
-     * @param string     $name e.g. duration_seconds
-     * @param string     $help e.g. A histogram of the duration in seconds.
-     * @param string[]   $labels e.g. ['controller', 'action']
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param string[] $labels e.g. ['controller', 'action']
      * @param mixed[]|null $buckets e.g. [100, 200, 300]
      *
      * @return Histogram
@@ -233,17 +233,17 @@ class CollectorRegistry implements RegistryInterface
     public function getHistogram(string $namespace, string $name): Histogram
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
-        if (! isset($this->histograms[$metricIdentifier])) {
+        if (!isset($this->histograms[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
         return $this->histograms[self::metricIdentifier($namespace, $name)];
     }
 
     /**
-     * @param string     $namespace e.g. cms
-     * @param string     $name e.g. duration_seconds
-     * @param string     $help e.g. A histogram of the duration in seconds.
-     * @param string[]      $labels e.g. ['controller', 'action']
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param string[] $labels e.g. ['controller', 'action']
      * @param float[]|null $buckets e.g. [100, 200, 300]
      *
      * @return Histogram

--- a/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
+++ b/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
@@ -361,6 +361,63 @@ EOF
         self::assertSame($histogramA, $histogramB);
     }
 
+    /**
+     * @test
+     * @dataProvider itShouldThrowAnExceptionOnInvalidMetricNamesDataProvider
+     */
+    public function itShouldThrowAnExceptionOnInvalidMetricNames(string $namespace, string $metricName): void
+    {
+        $registry = new CollectorRegistry($this->adapter);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $registry->registerGauge($namespace, $metricName, 'help', ["foo", "bar"]);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function itShouldThrowAnExceptionOnInvalidMetricNamesDataProvider(): array
+    {
+        return [
+            [
+                "foo",
+                "invalid-metric-name"
+            ],
+            [
+                "invalid-namespace",
+                "foo"
+            ],
+            [
+                "invalid-namespace",
+                "both-invalid"
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itShouldThrowAnExceptionOnInvalidMetricLabelDataProvider
+     */
+    public function itShouldThrowAnExceptionOnInvalidMetricLabel(string $invalidLabel): void
+    {
+        $registry = new CollectorRegistry($this->adapter);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $registry->registerGauge("foo", "bar", 'help', [$invalidLabel]);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function itShouldThrowAnExceptionOnInvalidMetricLabelDataProvider(): array
+    {
+        return [
+            [
+                "invalid-label"
+            ],
+        ];
+    }
+
 
     abstract public function configureAdapter(): void;
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

This brings basically a solution for #40. 
In my opinion, we should not validate the metric before we pass it into the storage if someone uses the storage implementations without using our Collectors. Having validation methods on the other hand makes it easier for users to pass correct metric names & label keys.

Fixes #40 