### PR TITLE
Fix tracking of float counters in Redis

### DIFF
--- a/examples/some_counter.php
+++ b/examples/some_counter.php
@@ -17,7 +17,11 @@ if ($adapter === 'redis') {
 }
 $registry = new CollectorRegistry($adapter);
 
+$count = preg_match('/^[0-9]+$/', $_GET['c'])
+    ? intval($_GET['c'])
+    : floatval($_GET['c']);
+
 $counter = $registry->registerCounter('test', 'some_counter', 'it increases', ['type']);
-$counter->incBy($_GET['c'], ['blue']);
+$counter->incBy($count, ['blue']);
 
 echo "OK\n";

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -288,9 +288,9 @@ LUA
         $this->redis->eval(
             <<<LUA
 local result = redis.call(ARGV[1], KEYS[1], ARGV[3], ARGV[2])
-if result == tonumber(ARGV[2]) then
+local added = redis.call('sAdd', KEYS[2], KEYS[1])
+if added == 1 then
     redis.call('hMSet', KEYS[1], '__meta', ARGV[4])
-    redis.call('sAdd', KEYS[2], KEYS[1])
 end
 return result
 LUA


### PR DESCRIPTION
Also update the example used by the tests to convert the given count to a number instead of passing a string (which would always be handled as an int).

Fixes #39