### PR TITLE
Make APCu key prefix configurable

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -11,17 +11,20 @@ use RuntimeException;
 
 class APC implements Adapter
 {
+    /** @var string Default prefix to use for APC keys. */
+    const PROMETHEUS_PREFIX = 'prom';
+
     /** @var string Prefix to use for APC keys. */
     private $prometheusPrefix;
 
     /**
      * APC constructor.
      *
-     * @param string $prometheusPrefix Prefix for APCu keys (defaults to 'prom').
+     * @param string $prometheusPrefix Prefix for APCu keys (defaults to {@see PROMETHEUS_PREFIX}).
      *
      * @throws StorageException
      */
-    public function __construct(string $prometheusPrefix = 'prom')
+    public function __construct(string $prometheusPrefix = self::PROMETHEUS_PREFIX)
     {
         if (!extension_loaded('apcu')) {
             throw new StorageException('APCu extension is not loaded');

--- a/tests/Test/Prometheus/Storage/APCTest.php
+++ b/tests/Test/Prometheus/Storage/APCTest.php
@@ -41,4 +41,29 @@ class APCTest extends TestCase
             ])
         );
     }
+
+    /**
+     * @test
+     */
+    public function itShouldUseConfiguredPrefix()
+    {
+        $apc = new APC('custom_prefix');
+        $apc->wipeStorage();
+
+        $registry = new CollectorRegistry($apc);
+
+        $registry->getOrRegisterCounter('namespace', 'counter', 'counter help')->inc();
+        $registry->getOrRegisterGauge('namespace', 'gauge', 'gauge help')->inc();
+        $registry->getOrRegisterHistogram('namespace', 'histogram', 'histogram help')->observe(1);
+
+        $entries = iterator_to_array(new APCUIterator('/^custom_prefix:.*:meta$/'), true);
+
+        $cacheKeys = array_map(function ($item) {
+            return $item['key'];
+        }, $entries);
+
+        self::assertArrayHasKey('custom_prefix:counter:namespace_counter:meta', $cacheKeys);
+        self::assertArrayHasKey('custom_prefix:gauge:namespace_gauge:meta', $cacheKeys);
+        self::assertArrayHasKey('custom_prefix:histogram:namespace_histogram:meta', $cacheKeys);
+    }
 }

--- a/tests/Test/Prometheus/Storage/APCTest.php
+++ b/tests/Test/Prometheus/Storage/APCTest.php
@@ -45,7 +45,7 @@ class APCTest extends TestCase
     /**
      * @test
      */
-    public function itShouldUseConfiguredPrefix()
+    public function itShouldUseConfiguredPrefix(): void
     {
         $apc = new APC('custom_prefix');
         $apc->wipeStorage();


### PR DESCRIPTION
Make the APCu key prefix configurable for the APC storage adapter.

This is useful if the default `prom` prefix is already used.