### PR TITLE
fix: Correctly register histograms with Redis

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -218,12 +218,13 @@ LUA
 
         $this->redis->eval(
             <<<LUA
-local increment = redis.call('hIncrByFloat', KEYS[1], ARGV[1], ARGV[3])
+local result = redis.call('hIncrByFloat', KEYS[1], ARGV[1], ARGV[3])
 redis.call('hIncrBy', KEYS[1], ARGV[2], 1)
-if increment == ARGV[3] then
+if tonumber(result) >= tonumber(ARGV[3]) then
     redis.call('hSet', KEYS[1], '__meta', ARGV[4])
     redis.call('sAdd', KEYS[2], KEYS[1])
 end
+return result
 LUA
             ,
             [


### PR DESCRIPTION
Hi folks,

I noticed that the LUA script for updating histograms currently does not work in many cases because it expected `HINCRBYFLOAT` to return the increment instead of the new value of field in the hash. It would also fail if the value returned by `HINCRBYFLOAT` differed in formatting from the input value. This PR fixes the issue.

Thanks,

Niels