### PR TITLE
Fix Gauge::decby value type

### DIFF
--- a/src/Prometheus/Gauge.php
+++ b/src/Prometheus/Gauge.php
@@ -77,10 +77,10 @@ class Gauge extends Collector
     }
 
     /**
-     * @param int $value
+     * @param int|float $value
      * @param string[] $labels
      */
-    public function decBy(int $value, array $labels = []): void
+    public function decBy($value, array $labels = []): void
     {
         $this->incBy(-$value, $labels);
     }


### PR DESCRIPTION
Hello. I've found some bug, I can't use float value type in `Gauge::decBy`, but I can do it in `Gauge::incBy`. Please check this fix 