### PR TITLE
validate names for apcu

### DIFF
--- a/src/Prometheus/Histogram.php
+++ b/src/Prometheus/Histogram.php
@@ -6,6 +6,7 @@ namespace Prometheus;
 
 use InvalidArgumentException;
 use Prometheus\Storage\Adapter;
+use Prometheus\Storage\APC;
 
 class Histogram extends Collector
 {

--- a/src/Prometheus/Histogram.php
+++ b/src/Prometheus/Histogram.php
@@ -6,7 +6,6 @@ namespace Prometheus;
 
 use InvalidArgumentException;
 use Prometheus\Storage\Adapter;
-use Prometheus\Storage\APC;
 
 class Histogram extends Collector
 {


### PR DESCRIPTION
With APC adapter meta-information is broken, if use colons in names of metrics. It gives hard to debug error. I am add validation of names when use APC adapter