### PR TITLE
Enable usage of metrics with same name but different labels

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -80,9 +80,9 @@ class CollectorRegistry implements RegistryInterface
      * @return Gauge
      * @throws MetricsRegistrationException
      */
-    public function registerGauge(string $namespace, string $name, string $help, $labels = []): Gauge
+    public function registerGauge(string $namespace, string $name, string $help, array $labels = []): Gauge
     {
-        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        $metricIdentifier = self::metricIdentifier($namespace, $name, $labels);
         if (isset($this->gauges[$metricIdentifier])) {
             throw new MetricsRegistrationException("Metric already registered");
         }
@@ -99,13 +99,14 @@ class CollectorRegistry implements RegistryInterface
     /**
      * @param string $namespace
      * @param string $name
+     * @param string[] $labels
      *
      * @return Gauge
      * @throws MetricNotFoundException
      */
-    public function getGauge(string $namespace, string $name): Gauge
+    public function getGauge(string $namespace, string $name, array $labels = []): Gauge
     {
-        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        $metricIdentifier = self::metricIdentifier($namespace, $name, $labels);
         if (!isset($this->gauges[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
@@ -121,10 +122,10 @@ class CollectorRegistry implements RegistryInterface
      * @return Gauge
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterGauge(string $namespace, string $name, string $help, $labels = []): Gauge
+    public function getOrRegisterGauge(string $namespace, string $name, string $help, array $labels = []): Gauge
     {
         try {
-            $gauge = $this->getGauge($namespace, $name);
+            $gauge = $this->getGauge($namespace, $name, $labels);
         } catch (MetricNotFoundException $e) {
             $gauge = $this->registerGauge($namespace, $name, $help, $labels);
         }
@@ -140,9 +141,9 @@ class CollectorRegistry implements RegistryInterface
      * @return Counter
      * @throws MetricsRegistrationException
      */
-    public function registerCounter(string $namespace, string $name, string $help, $labels = []): Counter
+    public function registerCounter(string $namespace, string $name, string $help, array $labels = []): Counter
     {
-        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        $metricIdentifier = self::metricIdentifier($namespace, $name, $labels);
         if (isset($this->counters[$metricIdentifier])) {
             throw new MetricsRegistrationException("Metric already registered");
         }
@@ -153,23 +154,24 @@ class CollectorRegistry implements RegistryInterface
             $help,
             $labels
         );
-        return $this->counters[self::metricIdentifier($namespace, $name)];
+        return $this->counters[$metricIdentifier];
     }
 
     /**
      * @param string $namespace
      * @param string $name
+     * @param string[] $labels
      *
      * @return Counter
      * @throws MetricNotFoundException
      */
-    public function getCounter(string $namespace, string $name): Counter
+    public function getCounter(string $namespace, string $name, array $labels = []): Counter
     {
-        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        $metricIdentifier = self::metricIdentifier($namespace, $name, $labels);
         if (!isset($this->counters[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
-        return $this->counters[self::metricIdentifier($namespace, $name)];
+        return $this->counters[$metricIdentifier];
     }
 
     /**
@@ -181,10 +183,10 @@ class CollectorRegistry implements RegistryInterface
      * @return Counter
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterCounter(string $namespace, string $name, string $help, $labels = []): Counter
+    public function getOrRegisterCounter(string $namespace, string $name, string $help, array $labels = []): Counter
     {
         try {
-            $counter = $this->getCounter($namespace, $name);
+            $counter = $this->getCounter($namespace, $name, $labels);
         } catch (MetricNotFoundException $e) {
             $counter = $this->registerCounter($namespace, $name, $help, $labels);
         }
@@ -208,7 +210,7 @@ class CollectorRegistry implements RegistryInterface
         array $labels = [],
         array $buckets = null
     ): Histogram {
-        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        $metricIdentifier = self::metricIdentifier($namespace, $name, $labels);
         if (isset($this->histograms[$metricIdentifier])) {
             throw new MetricsRegistrationException("Metric already registered");
         }
@@ -226,17 +228,18 @@ class CollectorRegistry implements RegistryInterface
     /**
      * @param string $namespace
      * @param string $name
+     * @param string[] $labels
      *
      * @return Histogram
      * @throws MetricNotFoundException
      */
-    public function getHistogram(string $namespace, string $name): Histogram
+    public function getHistogram(string $namespace, string $name, array $labels = []): Histogram
     {
-        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        $metricIdentifier = self::metricIdentifier($namespace, $name, $labels);
         if (!isset($this->histograms[$metricIdentifier])) {
             throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
         }
-        return $this->histograms[self::metricIdentifier($namespace, $name)];
+        return $this->histograms[$metricIdentifier];
     }
 
     /**
@@ -257,7 +260,7 @@ class CollectorRegistry implements RegistryInterface
         array $buckets = null
     ): Histogram {
         try {
-            $histogram = $this->getHistogram($namespace, $name);
+            $histogram = $this->getHistogram($namespace, $name, $labels);
         } catch (MetricNotFoundException $e) {
             $histogram = $this->registerHistogram($namespace, $name, $help, $labels, $buckets);
         }
@@ -267,12 +270,13 @@ class CollectorRegistry implements RegistryInterface
     /**
      * @param string $namespace
      * @param string $name
+     * @param string[] $labels
      *
      * @return string
      */
-    private static function metricIdentifier(string $namespace, string $name): string
+    private static function metricIdentifier(string $namespace, string $name, array $labels = []): string
     {
-        return $namespace . ":" . $name;
+        return $namespace . ":" . $name . ':' . implode('|', $labels);
     }
 
     private function registerDefaultMetrics(): void

--- a/src/Prometheus/MetricFamilySamples.php
+++ b/src/Prometheus/MetricFamilySamples.php
@@ -39,7 +39,6 @@ class MetricFamilySamples
         $this->name = $data['name'];
         $this->type = $data['type'];
         $this->help = $data['help'];
-        $this->labelNames = $data['labelNames'];
         foreach ($data['samples'] as $sampleData) {
             $this->samples[] = new Sample($sampleData);
         }
@@ -75,21 +74,5 @@ class MetricFamilySamples
     public function getSamples(): array
     {
         return $this->samples;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getLabelNames(): array
-    {
-        return $this->labelNames;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasLabelNames(): bool
-    {
-        return $this->labelNames !== [];
     }
 }

--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -36,9 +36,8 @@ class RenderTextFormat implements RendererInterface
      */
     private function renderSample(MetricFamilySamples $metric, Sample $sample): string
     {
-        $labelNames = $metric->getLabelNames();
-        if ($metric->hasLabelNames() || $sample->hasLabelNames()) {
-            $escapedLabels = $this->escapeAllLabels($labelNames, $sample);
+        if ($sample->hasLabelNames()) {
+            $escapedLabels = $this->escapeAllLabels($sample);
             return $sample->getName() . '{' . implode(',', $escapedLabels) . '} ' . $sample->getValue();
         }
         return $sample->getName() . ' ' . $sample->getValue();
@@ -54,16 +53,15 @@ class RenderTextFormat implements RendererInterface
     }
 
     /**
-     * @param string[]  $labelNames
      * @param Sample $sample
      *
      * @return string[]
      */
-    private function escapeAllLabels(array $labelNames, Sample $sample): array
+    private function escapeAllLabels(Sample $sample): array
     {
         $escapedLabels = [];
 
-        $labels = array_combine(array_merge($labelNames, $sample->getLabelNames()), $sample->getLabelValues());
+        $labels = array_combine($sample->getLabelNames(), $sample->getLabelValues());
 
         if ($labels === false) {
             return [];

--- a/tests/Test/Prometheus/APC/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/APC/RenderTextFormatTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\APC;
+
+use Prometheus\Storage\APC;
+use Test\Prometheus\AbstractRenderTextFormatTest;
+
+/**
+ * @requires extension apcu
+ */
+class RenderTextFormatTest extends AbstractRenderTextFormatTest
+{
+
+    public function configureAdapter(): void
+    {
+        $this->adapter = new APC();
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/AbstractCounterTest.php
+++ b/tests/Test/Prometheus/AbstractCounterTest.php
@@ -46,13 +46,12 @@ abstract class AbstractCounterTest extends TestCase
                             'type' => Counter::TYPE,
                             'help' => 'this is for testing',
                             'name' => 'test_some_metric',
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 3,
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                 ],
                             ],
                         ]
@@ -78,7 +77,6 @@ abstract class AbstractCounterTest extends TestCase
                             'type' => Counter::TYPE,
                             'help' => 'this is for testing',
                             'name' => 'test_some_metric',
-                            'labelNames' => [],
                             'samples' => [
                                 [
                                     'labelValues' => [],
@@ -111,13 +109,12 @@ abstract class AbstractCounterTest extends TestCase
                             'type' => Counter::TYPE,
                             'help' => 'this is for testing',
                             'name' => 'test_some_metric',
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 124,
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                 ],
                             ],
                         ]
@@ -144,13 +141,12 @@ abstract class AbstractCounterTest extends TestCase
                             'type' => Counter::TYPE,
                             'help' => 'this is for testing',
                             'name' => 'test_some_metric',
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 2.5,
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                 ],
                             ],
                         ]
@@ -202,7 +198,7 @@ abstract class AbstractCounterTest extends TestCase
 
         foreach ($samples as $sample) {
             $labels = array_combine(
-                array_merge($metric->getLabelNames(), $sample->getLabelNames()),
+                $sample->getLabelNames(),
                 $sample->getLabelValues()
             );
             self::assertIsArray($labels);

--- a/tests/Test/Prometheus/AbstractGaugeTest.php
+++ b/tests/Test/Prometheus/AbstractGaugeTest.php
@@ -44,11 +44,10 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 123,
                                 ],
@@ -78,7 +77,6 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => [],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
@@ -112,7 +110,6 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => [],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
@@ -147,11 +144,10 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 124,
                                 ],
@@ -180,11 +176,10 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 124.5,
                                 ],
@@ -213,11 +208,10 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => -124,
                                 ],
@@ -246,11 +240,10 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => -124,
                                 ],
@@ -279,11 +272,10 @@ abstract class AbstractGaugeTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Gauge::TYPE,
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 321,
                                 ],
@@ -336,7 +328,7 @@ abstract class AbstractGaugeTest extends TestCase
 
         foreach ($samples as $sample) {
             $labels = array_combine(
-                array_merge($metric->getLabelNames(), $sample->getLabelNames()),
+                $sample->getLabelNames(),
                 $sample->getLabelValues()
             );
             self::assertIsArray($labels);

--- a/tests/Test/Prometheus/AbstractHistogramTest.php
+++ b/tests/Test/Prometheus/AbstractHistogramTest.php
@@ -71,41 +71,40 @@ abstract class AbstractHistogramTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Histogram::TYPE,
-                            'labelNames' => ['foo', 'bar'],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric_bucket',
-                                    'labelNames' => ['le'],
+                                    'labelNames' => ['foo', 'bar', 'le'],
                                     'labelValues' => ['lalal', 'lululu', 100],
                                     'value' => 0,
                                 ],
                                 [
                                     'name' => 'test_some_metric_bucket',
-                                    'labelNames' => ['le'],
+                                    'labelNames' => ['foo', 'bar', 'le'],
                                     'labelValues' => ['lalal', 'lululu', 200],
                                     'value' => 1,
                                 ],
                                 [
                                     'name' => 'test_some_metric_bucket',
-                                    'labelNames' => ['le'],
+                                    'labelNames' => ['foo', 'bar', 'le'],
                                     'labelValues' => ['lalal', 'lululu', 300],
                                     'value' => 2,
                                 ],
                                 [
                                     'name' => 'test_some_metric_bucket',
-                                    'labelNames' => ['le'],
+                                    'labelNames' => ['foo', 'bar', 'le'],
                                     'labelValues' => ['lalal', 'lululu', '+Inf'],
                                     'value' => 2,
                                 ],
                                 [
                                     'name' => 'test_some_metric_count',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 2,
                                 ],
                                 [
                                     'name' => 'test_some_metric_sum',
-                                    'labelNames' => [],
+                                    'labelNames' => ['foo', 'bar'],
                                     'labelValues' => ['lalal', 'lululu'],
                                     'value' => 368,
                                 ],
@@ -140,7 +139,6 @@ abstract class AbstractHistogramTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Histogram::TYPE,
-                            'labelNames' => [],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric_bucket',
@@ -210,7 +208,6 @@ abstract class AbstractHistogramTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Histogram::TYPE,
-                            'labelNames' => [],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric_bucket',
@@ -302,7 +299,6 @@ abstract class AbstractHistogramTest extends TestCase
                             'name' => 'test_some_metric',
                             'help' => 'this is for testing',
                             'type' => Histogram::TYPE,
-                            'labelNames' => [],
                             'samples' => [
                                 [
                                     'name' => 'test_some_metric_bucket',
@@ -487,7 +483,7 @@ abstract class AbstractHistogramTest extends TestCase
 
         foreach ($samples as $sample) {
             $labels = array_combine(
-                array_merge($metric->getLabelNames(), $sample->getLabelNames()),
+                $sample->getLabelNames(),
                 $sample->getLabelValues()
             );
             self::assertIsArray($labels);

--- a/tests/Test/Prometheus/AbstractRenderTextFormatTest.php
+++ b/tests/Test/Prometheus/AbstractRenderTextFormatTest.php
@@ -10,9 +10,21 @@ use Prometheus\MetricFamilySamples;
 use Prometheus\RenderTextFormat;
 use PHPUnit\Framework\TestCase;
 use Prometheus\Storage\InMemory;
+use Prometheus\Storage\Adapter;
 
-class RenderTextFormatTest extends TestCase
+abstract class AbstractRenderTextFormatTest extends TestCase
 {
+    /**
+     * @var Adapter
+     */
+    public $adapter;
+
+    public function setUp(): void
+    {
+        $this->configureAdapter();
+    }
+
+    abstract public function configureAdapter(): void;
 
     public function testOutputMatchesExpectations(): void
     {
@@ -31,13 +43,19 @@ class RenderTextFormatTest extends TestCase
     private function buildSamples(): array
     {
         $namespace = 'mynamespace';
-        $registry = new CollectorRegistry(new InMemory(), false);
+        $registry = new CollectorRegistry($this->adapter, false);
         $registry->getOrRegisterCounter($namespace, 'counter', 'counter-help-text', ['label1', 'label2'])
                  ->inc(['bob', 'al\ice']);
+        $registry->getOrRegisterCounter($namespace, 'counter', 'counter-help-text')
+                 ->incBy(12);
         $registry->getOrRegisterGauge($namespace, 'gauge', 'counter-help-text', ['label1', 'label2'])
                  ->inc(["bo\nb", 'ali\"ce']);
+        $registry->getOrRegisterGauge($namespace, 'gauge', 'counter-help-text')
+                 ->set(25);
         $registry->getOrRegisterHistogram($namespace, 'histogram', 'counter-help-text', ['label1', 'label2'], [0, 10, 100])
                  ->observe(5, ['bob', 'alice']);
+        $registry->getOrRegisterHistogram($namespace, 'histogram', 'counter-help-text')
+                 ->observe(6);
 
         return $registry->getMetricFamilySamples();
     }
@@ -47,12 +65,31 @@ class RenderTextFormatTest extends TestCase
         return <<<TEXTPLAIN
 # HELP mynamespace_counter counter-help-text
 # TYPE mynamespace_counter counter
+mynamespace_counter 12
 mynamespace_counter{label1="bob",label2="al\\\\ice"} 1
 # HELP mynamespace_gauge counter-help-text
 # TYPE mynamespace_gauge gauge
+mynamespace_gauge 25
 mynamespace_gauge{label1="bo\\nb",label2="ali\\\\\"ce"} 1
 # HELP mynamespace_histogram counter-help-text
 # TYPE mynamespace_histogram histogram
+mynamespace_histogram_bucket{le="0.005"} 0
+mynamespace_histogram_bucket{le="0.01"} 0
+mynamespace_histogram_bucket{le="0.025"} 0
+mynamespace_histogram_bucket{le="0.05"} 0
+mynamespace_histogram_bucket{le="0.075"} 0
+mynamespace_histogram_bucket{le="0.1"} 0
+mynamespace_histogram_bucket{le="0.25"} 0
+mynamespace_histogram_bucket{le="0.5"} 0
+mynamespace_histogram_bucket{le="0.75"} 0
+mynamespace_histogram_bucket{le="1"} 0
+mynamespace_histogram_bucket{le="2.5"} 0
+mynamespace_histogram_bucket{le="5"} 0
+mynamespace_histogram_bucket{le="7.5"} 1
+mynamespace_histogram_bucket{le="10"} 1
+mynamespace_histogram_bucket{le="+Inf"} 1
+mynamespace_histogram_count 1
+mynamespace_histogram_sum 6
 mynamespace_histogram_bucket{label1="bob",label2="alice",le="0"} 0
 mynamespace_histogram_bucket{label1="bob",label2="alice",le="10"} 1
 mynamespace_histogram_bucket{label1="bob",label2="alice",le="100"} 1

--- a/tests/Test/Prometheus/InMemory/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/InMemory/RenderTextFormatTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\InMemory;
+
+use Prometheus\Storage\InMemory;
+use Test\Prometheus\AbstractRenderTextFormatTest;
+
+class RenderTextFormatTest extends AbstractRenderTextFormatTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new InMemory();
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Redis/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/Redis/RenderTextFormatTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Redis;
+
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractRenderTextFormatTest;
+
+/**
+ * @requires extension redis
+ */
+class RenderTextFormatTest extends AbstractRenderTextFormatTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new Redis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
+    }
+}


### PR DESCRIPTION
Hi there, this PR enables the user of this client lib to use different labels (names and values) for metrics.