### PR TITLE
Allow timestamp in metric samples

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -206,7 +206,8 @@ class CollectorRegistry implements RegistryInterface
         string $name,
         string $help,
         array $labels = [],
-        array $buckets = null
+        array $buckets = null,
+        ?int $timestamp = null
     ): Histogram {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
         if (isset($this->histograms[$metricIdentifier])) {
@@ -218,7 +219,8 @@ class CollectorRegistry implements RegistryInterface
             $name,
             $help,
             $labels,
-            $buckets
+            $buckets,
+            $timestamp
         );
         return $this->histograms[$metricIdentifier];
     }
@@ -254,12 +256,13 @@ class CollectorRegistry implements RegistryInterface
         string $name,
         string $help,
         array $labels = [],
-        array $buckets = null
+        array $buckets = null,
+        ?int $timestamp = null
     ): Histogram {
         try {
             $histogram = $this->getHistogram($namespace, $name);
         } catch (MetricNotFoundException $e) {
-            $histogram = $this->registerHistogram($namespace, $name, $help, $labels, $buckets);
+            $histogram = $this->registerHistogram($namespace, $name, $help, $labels, $buckets, $timestamp);
         }
         return $histogram;
     }

--- a/src/Prometheus/Counter.php
+++ b/src/Prometheus/Counter.php
@@ -21,16 +21,16 @@ class Counter extends Collector
     /**
      * @param string[] $labels e.g. ['status', 'opcode']
      */
-    public function inc(array $labels = []): void
+    public function inc(array $labels = [], ?int $timestamp = null): void
     {
-        $this->incBy(1, $labels);
+        $this->incBy(1, $labels, $timestamp);
     }
 
     /**
      * @param int|float $count e.g. 2
      * @param mixed[] $labels e.g. ['status', 'opcode']
      */
-    public function incBy($count, array $labels = []): void
+    public function incBy($count, array $labels = [], ?int $timestamp = null): void
     {
         $this->assertLabelsAreDefinedCorrectly($labels);
 
@@ -41,6 +41,7 @@ class Counter extends Collector
                 'type' => $this->getType(),
                 'labelNames' => $this->getLabelNames(),
                 'labelValues' => $labels,
+                'timestamp'   => $timestamp,
                 'value' => $count,
                 'command' => is_float($count) ? Adapter::COMMAND_INCREMENT_FLOAT : Adapter::COMMAND_INCREMENT_INTEGER,
             ]

--- a/src/Prometheus/Gauge.php
+++ b/src/Prometheus/Gauge.php
@@ -14,7 +14,7 @@ class Gauge extends Collector
      * @param double $value e.g. 123
      * @param string[] $labels e.g. ['status', 'opcode']
      */
-    public function set(float $value, array $labels = []): void
+    public function set(float $value, array $labels = [], ?int $timestamp = null): void
     {
         $this->assertLabelsAreDefinedCorrectly($labels);
 
@@ -26,6 +26,7 @@ class Gauge extends Collector
                 'labelNames' => $this->getLabelNames(),
                 'labelValues' => $labels,
                 'value' => $value,
+                'timestamp' => $timestamp,
                 'command' => Adapter::COMMAND_SET,
             ]
         );
@@ -42,16 +43,16 @@ class Gauge extends Collector
     /**
      * @param string[] $labels
      */
-    public function inc(array $labels = []): void
+    public function inc(array $labels = [], ?int $timestamp = null): void
     {
-        $this->incBy(1, $labels);
+        $this->incBy(1, $labels, $timestamp);
     }
 
     /**
      * @param int|float $value
      * @param string[] $labels
      */
-    public function incBy($value, array $labels = []): void
+    public function incBy($value, array $labels = [], ?int $timestamp = null): void
     {
         $this->assertLabelsAreDefinedCorrectly($labels);
 
@@ -62,6 +63,7 @@ class Gauge extends Collector
                 'type' => $this->getType(),
                 'labelNames' => $this->getLabelNames(),
                 'labelValues' => $labels,
+                'timestamp'   => $timestamp,
                 'value' => $value,
                 'command' => Adapter::COMMAND_INCREMENT_FLOAT,
             ]

--- a/src/Prometheus/RegistryInterface.php
+++ b/src/Prometheus/RegistryInterface.php
@@ -111,5 +111,5 @@ interface RegistryInterface
      * @return Histogram
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterHistogram(string $namespace, string $name, string $help, array $labels = [], array $buckets = null): Histogram;
+    public function getOrRegisterHistogram(string $namespace, string $name, string $help, array $labels = [], array $buckets = null, ?int $timestamp = null): Histogram;
 }

--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -37,11 +37,13 @@ class RenderTextFormat implements RendererInterface
     private function renderSample(MetricFamilySamples $metric, Sample $sample): string
     {
         $labelNames = $metric->getLabelNames();
+        $timestamp = $sample->getTimestamp();
+        $timestampPart = $timestamp === null ? '' : ' ' . $timestamp;
         if ($metric->hasLabelNames() || $sample->hasLabelNames()) {
             $escapedLabels = $this->escapeAllLabels($labelNames, $sample);
-            return $sample->getName() . '{' . implode(',', $escapedLabels) . '} ' . $sample->getValue();
+            return $sample->getName() . '{' . implode(',', $escapedLabels) . '} ' . $sample->getValue() . $timestampPart;
         }
-        return $sample->getName() . ' ' . $sample->getValue();
+        return $sample->getName() . ' ' . $sample->getValue() . $timestampPart;
     }
 
     /**

--- a/src/Prometheus/Sample.php
+++ b/src/Prometheus/Sample.php
@@ -27,6 +27,11 @@ class Sample
     private $value;
 
     /**
+     * @var int|null
+     */
+    private $timestamp;
+
+    /**
      * Sample constructor.
      * @param mixed[] $data
      */
@@ -36,6 +41,7 @@ class Sample
         $this->labelNames = (array) $data['labelNames'];
         $this->labelValues = (array) $data['labelValues'];
         $this->value = $data['value'];
+        $this->timestamp = $data['timestamp'];
     }
 
     /**
@@ -68,6 +74,11 @@ class Sample
     public function getValue(): string
     {
         return (string) $this->value;
+    }
+
+    public function getTimestamp(): ?int
+    {
+        return $this->timestamp;
     }
 
     /**

--- a/tests/Test/Prometheus/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/RenderTextFormatTest.php
@@ -34,9 +34,9 @@ class RenderTextFormatTest extends TestCase
         $registry = new CollectorRegistry(new InMemory(), false);
         $registry->getOrRegisterCounter($namespace, 'counter', 'counter-help-text', ['label1', 'label2'])
                  ->inc(['bob', 'al\ice']);
-        $registry->getOrRegisterGauge($namespace, 'gauge', 'counter-help-text', ['label1', 'label2'])
+        $registry->getOrRegisterGauge($namespace, 'gauge', 'gauge-help-text', ['label1', 'label2'])
                  ->inc(["bo\nb", 'ali\"ce']);
-        $registry->getOrRegisterHistogram($namespace, 'histogram', 'counter-help-text', ['label1', 'label2'], [0, 10, 100])
+        $registry->getOrRegisterHistogram($namespace, 'histogram', 'histogram-help-text', ['label1', 'label2'], [0, 10, 100])
                  ->observe(5, ['bob', 'alice']);
 
         return $registry->getMetricFamilySamples();
@@ -48,10 +48,10 @@ class RenderTextFormatTest extends TestCase
 # HELP mynamespace_counter counter-help-text
 # TYPE mynamespace_counter counter
 mynamespace_counter{label1="bob",label2="al\\\\ice"} 1
-# HELP mynamespace_gauge counter-help-text
+# HELP mynamespace_gauge gauge-help-text
 # TYPE mynamespace_gauge gauge
 mynamespace_gauge{label1="bo\\nb",label2="ali\\\\\"ce"} 1
-# HELP mynamespace_histogram counter-help-text
+# HELP mynamespace_histogram histogram-help-text
 # TYPE mynamespace_histogram histogram
 mynamespace_histogram_bucket{label1="bob",label2="alice",le="0"} 0
 mynamespace_histogram_bucket{label1="bob",label2="alice",le="10"} 1

--- a/tests/Test/Prometheus/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/RenderTextFormatTest.php
@@ -34,8 +34,12 @@ class RenderTextFormatTest extends TestCase
         $registry = new CollectorRegistry(new InMemory(), false);
         $registry->getOrRegisterCounter($namespace, 'counter', 'counter-help-text', ['label1', 'label2'])
                  ->inc(['bob', 'al\ice']);
+        $registry->getOrRegisterCounter($namespace, 'counter_with_timestamp', 'counter-with-timestamp-help-text', ['label1', 'label2'])
+                 ->inc(['bob', 'al\ice'], 1395066363000);
         $registry->getOrRegisterGauge($namespace, 'gauge', 'gauge-help-text', ['label1', 'label2'])
                  ->inc(["bo\nb", 'ali\"ce']);
+        $registry->getOrRegisterGauge($namespace, 'gauge_with_timestamp', 'gauge-with-timestamp-help-text', ['label1', 'label2'])
+                 ->inc(["bo\nb", 'ali\"ce'], 1395066363000);
         $registry->getOrRegisterHistogram($namespace, 'histogram', 'histogram-help-text', ['label1', 'label2'], [0, 10, 100])
                  ->observe(5, ['bob', 'alice']);
 
@@ -48,9 +52,15 @@ class RenderTextFormatTest extends TestCase
 # HELP mynamespace_counter counter-help-text
 # TYPE mynamespace_counter counter
 mynamespace_counter{label1="bob",label2="al\\\\ice"} 1
+# HELP mynamespace_counter_with_timestamp counter-with-timestamp-help-text
+# TYPE mynamespace_counter_with_timestamp counter
+mynamespace_counter_with_timestamp{label1="bob",label2="al\\\\ice"} 1 1395066363000
 # HELP mynamespace_gauge gauge-help-text
 # TYPE mynamespace_gauge gauge
 mynamespace_gauge{label1="bo\\nb",label2="ali\\\\\"ce"} 1
+# HELP mynamespace_gauge_with_timestamp gauge-with-timestamp-help-text
+# TYPE mynamespace_gauge_with_timestamp gauge
+mynamespace_gauge_with_timestamp{label1="bo\\nb",label2="ali\\\\\"ce"} 1 1395066363000
 # HELP mynamespace_histogram histogram-help-text
 # TYPE mynamespace_histogram histogram
 mynamespace_histogram_bucket{label1="bob",label2="alice",le="0"} 0


### PR DESCRIPTION
Metric line can also contain optional timestamp.

```
http_requests_total{method="post",code="200"}  0
http_requests_total{method="post",code="400"}  3   1395066363000
```

Should I move forward with this?

- [x] support of timestamp in gauge
- [x] support of timestamp in counter
- [ ] support of timestamp in histogram (should we have this)
- [x] support in InMemory adapter
- [ ] support in Redis adapter
- [ ] support in APC adapter