### PR TITLE
More detailed access logs from php-fpm container

### DIFF
--- a/php-fpm/www.conf
+++ b/php-fpm/www.conf
@@ -4,3 +4,4 @@ group = www-data
 listen = 127.0.0.1:9000
 pm = static
 pm.max_children = 20
+access.format = "%R %p [%t] \"%m %r\" %s %{micro}d %C %M %l"


### PR DESCRIPTION
Increases the level of detail in the php-fpm access log file. The updated access log format removes `%u` (the username associated with the request) and adds the following:

`%p` The PID of the process servicing the request
`%{micro}d` The time taken to serve the request, in microseconds
`%C` Total %CPU used to serve the request
`%M` Peak memory allocated by PHP to serve the request, bytes
`%l` Content-length of the request
The resulting access log entry, formatted with `%R %p [%t] \"%m %r\" %s %{micro}d %C %M %l`, looks like this:

`172.17.0.4 27 [27/Oct/2021:08:27:15 +0000] "GET /examples/some_counter.php" 200 181812 5.50 2097152 0`

This is useful in determining execution-time and resource-usage of requests when doing performance testing or when tracking down blackbox testing anomalies. In most cases the access logs are never needed, but when they are this additional detail is nice to have compared to the default log format.