### PR TITLE
Properly validate label names

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ composer require promphp/prometheus_push_gateway_php
 
 Start a Redis instance:
 ```
-docker-compose up Redis
+docker-compose up redis
 ```
 
 Run the tests:

--- a/src/Prometheus/Collector.php
+++ b/src/Prometheus/Collector.php
@@ -117,5 +117,8 @@ abstract class Collector
         if (preg_match(self::RE_LABEL_NAME, $label) !== 1) {
             throw new InvalidArgumentException("Invalid label name: '" . $label . "'");
         }
+        else if (strpos($label, "__") === 0) {
+            throw new InvalidArgumentException("Can't used a reserved label name: '" . $label . "'");
+        }
     }
 }

--- a/src/Prometheus/Collector.php
+++ b/src/Prometheus/Collector.php
@@ -9,7 +9,8 @@ use Prometheus\Storage\Adapter;
 
 abstract class Collector
 {
-    const RE_METRIC_LABEL_NAME = '/^[a-zA-Z_:][a-zA-Z0-9_:]*$/';
+    const RE_METRIC_NAME = '/^[a-zA-Z_:][a-zA-Z0-9_:]*$/';
+    const RE_LABEL_NAME = '/^[a-zA-Z_][a-zA-Z0-9_]*$/';
 
     /**
      * @var Adapter
@@ -103,7 +104,7 @@ abstract class Collector
      */
     public static function assertValidMetricName(string $metricName): void
     {
-        if (preg_match(self::RE_METRIC_LABEL_NAME, $metricName) !== 1) {
+        if (preg_match(self::RE_METRIC_NAME, $metricName) !== 1) {
             throw new InvalidArgumentException("Invalid metric name: '" . $metricName . "'");
         }
     }
@@ -113,7 +114,7 @@ abstract class Collector
      */
     public static function assertValidLabel(string $label): void
     {
-        if (preg_match(self::RE_METRIC_LABEL_NAME, $label) !== 1) {
+        if (preg_match(self::RE_LABEL_NAME, $label) !== 1) {
             throw new InvalidArgumentException("Invalid label name: '" . $label . "'");
         }
     }

--- a/tests/Test/Prometheus/CollectorTest.php
+++ b/tests/Test/Prometheus/CollectorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus;
+
+use PHPUnit\Framework\TestCase;
+use Prometheus\CollectorRegistry;
+use Prometheus\Storage\InMemory;
+
+class CollectorTest extends TestCase
+{
+    /**
+     * @var CollectorRegistry
+     */
+    public $registry;
+
+    public function setUp(): void
+    {
+        $this->registry = new CollectorRegistry(new InMemory(), false);
+    }
+
+    public function testInvalidNamespace(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->registry->getOrRegisterCounter('bad%namespace', 'counter', 'counter-help-text');
+    }
+
+    public function testInvalidMetricName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->registry->getOrRegisterCounter('mynamespace', 'coun^ter', 'counter-help-text');
+    }
+
+    public function testInvalidLabelName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->registry->getOrRegisterCounter('mynamespace', 'counter', 'counter-help-text', ['label1','label:2']);
+    }
+}

--- a/tests/Test/Prometheus/CollectorTest.php
+++ b/tests/Test/Prometheus/CollectorTest.php
@@ -37,4 +37,10 @@ class CollectorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->registry->getOrRegisterCounter('mynamespace', 'counter', 'counter-help-text', ['label1','label:2']);
     }
+
+    public function testReservedLabelName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->registry->getOrRegisterCounter('mynamespace', 'counter', 'counter-help-text', ['__reserved']);
+    }
 }


### PR DESCRIPTION
The label name validation function was using the same regex as for the metric names.  But according to the [official prometheus docs](https://prometheus.io/docs/concepts/data_model/) the label names need to conform to a slightly different pattern.  A check is also done for reserved label names; any that start with a double underscore (__).

Unit tests added and pass.