### PR TITLE
feat: allow to disable metric sort

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -81,9 +81,9 @@ class CollectorRegistry implements RegistryInterface
     /**
      * @return MetricFamilySamples[]
      */
-    public function getMetricFamilySamples(): array
+    public function getMetricFamilySamples(bool $sortMetrics = true): array
     {
-        return $this->storageAdapter->collect();
+        return $this->storageAdapter->collect($sortMetrics);
     }
 
     /**

--- a/src/Prometheus/RegistryInterface.php
+++ b/src/Prometheus/RegistryInterface.php
@@ -17,7 +17,7 @@ interface RegistryInterface
     /**
      * @return MetricFamilySamples[]
      */
-    public function getMetricFamilySamples(): array;
+    public function getMetricFamilySamples(bool $sortMetrics = true): array;
 
     /**
      * @param string   $namespace e.g. cms

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -40,11 +40,11 @@ class APC implements Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    public function collect(): array
+    public function collect(bool $sortMetrics = true): array
     {
         $metrics = $this->collectHistograms();
-        $metrics = array_merge($metrics, $this->collectGauges());
-        $metrics = array_merge($metrics, $this->collectCounters());
+        $metrics = array_merge($metrics, $this->collectGauges($sortMetrics));
+        $metrics = array_merge($metrics, $this->collectCounters($sortMetrics));
         $metrics = array_merge($metrics, $this->collectSummaries());
         return $metrics;
     }
@@ -238,7 +238,7 @@ class APC implements Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    private function collectCounters(): array
+    private function collectCounters(bool $sortMetrics = true): array
     {
         $counters = [];
         foreach (new APCuIterator('/^' . $this->prometheusPrefix . ':counter:.*:meta/') as $counter) {
@@ -260,7 +260,11 @@ class APC implements Adapter
                     'value' => $this->fromBinaryRepresentationAsInteger($value['value']),
                 ];
             }
-            $this->sortSamples($data['samples']);
+
+            if ($sortMetrics) {
+                $this->sortSamples($data['samples']);
+            }
+
             $counters[] = new MetricFamilySamples($data);
         }
         return $counters;
@@ -269,7 +273,7 @@ class APC implements Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    private function collectGauges(): array
+    private function collectGauges(bool $sortMetrics = true): array
     {
         $gauges = [];
         foreach (new APCuIterator('/^' . $this->prometheusPrefix . ':gauge:.*:meta/') as $gauge) {
@@ -292,7 +296,10 @@ class APC implements Adapter
                 ];
             }
 
-            $this->sortSamples($data['samples']);
+            if ($sortMetrics) {
+                $this->sortSamples($data['samples']);
+            }
+
             $gauges[] = new MetricFamilySamples($data);
         }
         return $gauges;

--- a/src/Prometheus/Storage/APCng.php
+++ b/src/Prometheus/Storage/APCng.php
@@ -73,11 +73,11 @@ class APCng implements Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    public function collect(): array
+    public function collect(bool $sortMetrics = true): array
     {
         $metrics = $this->collectHistograms();
-        $metrics = array_merge($metrics, $this->collectGauges());
-        $metrics = array_merge($metrics, $this->collectCounters());
+        $metrics = array_merge($metrics, $this->collectGauges($sortMetrics));
+        $metrics = array_merge($metrics, $this->collectCounters($sortMetrics));
         $metrics = array_merge($metrics, $this->collectSummaries());
         return $metrics;
     }
@@ -441,7 +441,7 @@ class APCng implements Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    private function collectCounters(): array
+    private function collectCounters(bool $sortMetrics = true): array
     {
         $counters = [];
         foreach ($this->getMetas('counter') as $counter) {
@@ -463,7 +463,11 @@ class APCng implements Adapter
                     'value' => $this->convertIncrementalIntegerToFloat($value['value']),
                 ];
             }
-            $this->sortSamples($data['samples']);
+
+            if ($sortMetrics) {
+                $this->sortSamples($data['samples']);
+            }
+
             $counters[] = new MetricFamilySamples($data);
         }
         return $counters;
@@ -554,7 +558,7 @@ class APCng implements Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    private function collectGauges(): array
+    private function collectGauges(bool $sortMetrics = true): array
     {
         $gauges = [];
         foreach ($this->getMetas('gauge') as $gauge) {
@@ -576,7 +580,11 @@ class APCng implements Adapter
                     'value' => $this->convertIncrementalIntegerToFloat($value['value']),
                 ];
             }
-            $this->sortSamples($data['samples']);
+
+            if ($sortMetrics) {
+                $this->sortSamples($data['samples']);
+            }
+
             $gauges[] = new MetricFamilySamples($data);
         }
         return $gauges;

--- a/src/Prometheus/Storage/Adapter.php
+++ b/src/Prometheus/Storage/Adapter.php
@@ -16,7 +16,7 @@ interface Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    public function collect(): array;
+    public function collect(bool $sortMetrics = true): array;
 
     /**
      * @param mixed[] $data

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -33,10 +33,10 @@ class InMemory implements Adapter
     /**
      * @return MetricFamilySamples[]
      */
-    public function collect(): array
+    public function collect(bool $sortMetrics = true): array
     {
-        $metrics = $this->internalCollect($this->counters);
-        $metrics = array_merge($metrics, $this->internalCollect($this->gauges));
+        $metrics = $this->internalCollect($this->counters, $sortMetrics);
+        $metrics = array_merge($metrics, $this->internalCollect($this->gauges, $sortMetrics));
         $metrics = array_merge($metrics, $this->collectHistograms());
         $metrics = array_merge($metrics, $this->collectSummaries());
         return $metrics;
@@ -215,7 +215,7 @@ class InMemory implements Adapter
      * @param mixed[] $metrics
      * @return MetricFamilySamples[]
      */
-    protected function internalCollect(array $metrics): array
+    protected function internalCollect(array $metrics, bool $sortMetrics = true): array
     {
         $result = [];
         foreach ($metrics as $metric) {
@@ -237,7 +237,11 @@ class InMemory implements Adapter
                     'value' => $value,
                 ];
             }
-            $this->sortSamples($data['samples']);
+
+            if ($sortMetrics) {
+                $this->sortSamples($data['samples']);
+            }
+
             $result[] = new MetricFamilySamples($data);
         }
         return $result;

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -169,12 +169,12 @@ LUA
      * @return MetricFamilySamples[]
      * @throws StorageException
      */
-    public function collect(): array
+    public function collect(bool $sortMetrics = true): array
     {
         $this->ensureOpenConnection();
         $metrics = $this->collectHistograms();
-        $metrics = array_merge($metrics, $this->collectGauges());
-        $metrics = array_merge($metrics, $this->collectCounters());
+        $metrics = array_merge($metrics, $this->collectGauges($sortMetrics));
+        $metrics = array_merge($metrics, $this->collectCounters($sortMetrics));
         $metrics = array_merge($metrics, $this->collectSummaries());
         return array_map(
             function (array $metric): MetricFamilySamples {
@@ -569,7 +569,7 @@ LUA
     /**
      * @return mixed[]
      */
-    private function collectGauges(): array
+    private function collectGauges(bool $sortMetrics = true): array
     {
         $keys = $this->redis->sMembers(self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
         sort($keys);
@@ -587,9 +587,13 @@ LUA
                     'value' => $value,
                 ];
             }
-            usort($gauge['samples'], function ($a, $b): int {
-                return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
-            });
+
+            if ($sortMetrics) {
+                usort($gauge['samples'], function ($a, $b): int {
+                    return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
+                });
+            }
+
             $gauges[] = $gauge;
         }
         return $gauges;
@@ -598,7 +602,7 @@ LUA
     /**
      * @return mixed[]
      */
-    private function collectCounters(): array
+    private function collectCounters(bool $sortMetrics = true): array
     {
         $keys = $this->redis->sMembers(self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
         sort($keys);
@@ -616,9 +620,13 @@ LUA
                     'value' => $value,
                 ];
             }
-            usort($counter['samples'], function ($a, $b): int {
-                return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
-            });
+
+            if ($sortMetrics) {
+                usort($counter['samples'], function ($a, $b): int {
+                    return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
+                });
+            }
+
             $counters[] = $counter;
         }
         return $counters;

--- a/src/Prometheus/Storage/RedisNg.php
+++ b/src/Prometheus/Storage/RedisNg.php
@@ -169,12 +169,12 @@ LUA
      * @return MetricFamilySamples[]
      * @throws StorageException
      */
-    public function collect(): array
+    public function collect(bool $sortMetrics = true): array
     {
         $this->ensureOpenConnection();
         $metrics = $this->collectHistograms();
-        $metrics = array_merge($metrics, $this->collectGauges());
-        $metrics = array_merge($metrics, $this->collectCounters());
+        $metrics = array_merge($metrics, $this->collectGauges($sortMetrics));
+        $metrics = array_merge($metrics, $this->collectCounters($sortMetrics));
         $metrics = array_merge($metrics, $this->collectSummaries());
         return array_map(
             function (array $metric): MetricFamilySamples {
@@ -572,7 +572,7 @@ LUA
     /**
      * @return mixed[]
      */
-    private function collectGauges(): array
+    private function collectGauges(bool $sortMetrics = true): array
     {
         $keys = $this->redis->sMembers(self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
         sort($keys);
@@ -590,9 +590,13 @@ LUA
                     'value' => $value,
                 ];
             }
-            usort($gauge['samples'], function ($a, $b): int {
-                return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
-            });
+
+            if ($sortMetrics) {
+                usort($gauge['samples'], function ($a, $b): int {
+                    return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
+                });
+            }
+
             $gauges[] = $gauge;
         }
         return $gauges;
@@ -601,7 +605,7 @@ LUA
     /**
      * @return mixed[]
      */
-    private function collectCounters(): array
+    private function collectCounters(bool $sortMetrics = true): array
     {
         $keys = $this->redis->sMembers(self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
         sort($keys);
@@ -619,9 +623,13 @@ LUA
                     'value' => $value,
                 ];
             }
-            usort($counter['samples'], function ($a, $b): int {
-                return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
-            });
+
+            if ($sortMetrics) {
+                usort($counter['samples'], function ($a, $b): int {
+                    return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
+                });
+            }
+
             $counters[] = $counter;
         }
         return $counters;


### PR DESCRIPTION
This function does 50 % of a loading time (using inmemory adapter) so I'd like to be able to disable it.