### PR TITLE
Eliminate wlocks when updating existing histograms, gauges

### DIFF
--- a/src/Prometheus/Storage/APCng.php
+++ b/src/Prometheus/Storage/APCng.php
@@ -113,8 +113,11 @@ class APCng implements Adapter
         }
 
         // Initialize and increment the bucket
-        apcu_add($this->histogramBucketValueKey($data, $bucketToIncrease), 0);
-        apcu_inc($this->histogramBucketValueKey($data, $bucketToIncrease));
+        $bucketKey = $this->histogramBucketValueKey($data, $bucketToIncrease);
+        if (!apcu_exists($bucketKey)) {
+            apcu_add($bucketKey, 0);
+        }
+        apcu_inc($bucketKey);
     }
 
     /**


### PR DESCRIPTION
apcu_add always takes a wlock in the current version 5.1.22, which leads to lots of lock contention in high concurrency scenarios. Since the most common operation ought to be updating an already existing key, wrap apcu_add in an apcu_exists that only takes a rlock.