### PR TITLE
Added support of Predis library as storage adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,13 @@
         "phpstan/phpstan-phpunit": "^1.1.0",
         "phpstan/phpstan-strict-rules": "^1.1.0",
         "phpunit/phpunit": "^9.4",
+        "predis/predis": "^2.0",
         "squizlabs/php_codesniffer": "^3.6",
         "symfony/polyfill-apcu": "^1.6"
     },
     "suggest": {
         "ext-redis": "Required if using Redis.",
+        "predis/predis": "Required if using Predis.",
         "ext-apc": "Required if using APCu.",
         "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
         "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"

--- a/examples/metrics.php
+++ b/examples/metrics.php
@@ -11,6 +11,8 @@ $adapter = $_GET['adapter'];
 if ($adapter === 'redis') {
     Redis::setDefaultOptions(['host' => $_SERVER['REDIS_HOST'] ?? '127.0.0.1']);
     $adapter = new Prometheus\Storage\Redis();
+} elseif ($adapter === 'predis') {
+    $adapter = new Prometheus\Storage\Predis(['host' => $_SERVER['REDIS_HOST'] ?? '127.0.0.1']);
 } elseif ($adapter === 'apc') {
     $adapter = new Prometheus\Storage\APC();
 } elseif ($adapter === 'apcng') {

--- a/src/Prometheus/Storage/Predis.php
+++ b/src/Prometheus/Storage/Predis.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prometheus\Storage;
+
+use Predis\Configuration\Option\Prefix;
+use Prometheus\Exception\StorageException;
+use Predis\Client;
+
+/**
+ * @property Client $redis
+ */
+final class Predis extends Redis
+{
+    /**
+     * @var mixed[]
+     */
+    private static array $defaultOptions = [
+        'host' => '127.0.0.1',
+        'port' => 6379,
+        'scheme' => 'tcp',
+        'timeout' => 0.1,
+        'read_timeout' => '10',
+        'persistent' => 0,
+        'password' => null,
+    ];
+
+    public function __construct(array $options = [])
+    {
+        $this->options = array_merge(self::$defaultOptions, $options);
+
+        parent::__construct($options);
+
+        $this->redis = new Client($this->options);
+    }
+
+    public static function fromClient(Client $redis): self
+    {
+        if ($redis->isConnected() === false) {
+            throw new StorageException('Connection to Redis server not established');
+        }
+
+        $self = new self();
+        $self->redis = $redis;
+
+        return $self;
+    }
+
+    protected function ensureOpenConnection(): void
+    {
+        if ($this->redis->isConnected() === false) {
+            $this->redis->connect();
+        }
+    }
+
+    public static function fromExistingConnection(\Redis $redis): Redis
+    {
+        throw new \RuntimeException('This method is not supported by predis adapter');
+    }
+
+    protected function getGlobalPrefix(): ?string
+    {
+        if ($this->redis->getOptions()->prefix === null) {
+            return null;
+        }
+
+        if ($this->redis->getOptions()->prefix instanceof Prefix) {
+            return $this->redis->getOptions()->prefix->getPrefix();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $args
+     * @param int $keysCount
+     * @return mixed[]
+     */
+    protected function evalParams(array $args, int $keysCount): array
+    {
+        return  [$keysCount, ...$args];
+    }
+
+
+    protected function prefix(string $key): string
+    {
+        // the predis is doing key prefixing on its own
+        return '';
+    }
+
+    protected function setParams(array $input): array
+    {
+        $values = array_values($input);
+        $params = [];
+
+        if (isset($input['EX'])) {
+            $params[] = 'EX';
+            $params[] = $input['EX'];
+        }
+
+        if (isset($input['PX'])) {
+            $params[] = 'PX';
+            $params[] = $input['PX'];
+        }
+
+        $params[] = $values[0];
+
+        return $params;
+    }
+}

--- a/tests/Test/Prometheus/Predis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Predis/CollectorRegistryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Test\Prometheus\AbstractCollectorRegistryTest;
+
+/**
+ * @requires predis
+ */
+class CollectorRegistryTest extends AbstractCollectorRegistryTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new Predis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/CounterTest.php
+++ b/tests/Test/Prometheus/Predis/CounterTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Test\Prometheus\AbstractCounterTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class CounterTest extends AbstractCounterTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new Predis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/CounterWithPrefixTest.php
+++ b/tests/Test/Prometheus/Predis/CounterWithPrefixTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractCounterTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class CounterWithPrefixTest extends AbstractCounterTest
+{
+    public function configureAdapter(): void
+    {
+        $client = new Client([
+            'host'   => REDIS_HOST,
+            'prefix' => 'prefix:',
+        ]);
+
+        $client->connect();
+
+        $this->adapter = Predis::fromClient($client);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/GaugeTest.php
+++ b/tests/Test/Prometheus/Predis/GaugeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractGaugeTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class GaugeTest extends AbstractGaugeTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new Predis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/GaugeWithPrefixTest.php
+++ b/tests/Test/Prometheus/Predis/GaugeWithPrefixTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Test\Prometheus\AbstractGaugeTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class GaugeWithPrefixTest extends AbstractGaugeTest
+{
+    public function configureAdapter(): void
+    {
+        $client = new Client([
+            'host'   => REDIS_HOST,
+            'prefix' => 'prefix:',
+        ]);
+
+        $client->connect();
+
+        $this->adapter = Predis::fromClient($client);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/HistogramTest.php
+++ b/tests/Test/Prometheus/Predis/HistogramTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractHistogramTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class HistogramTest extends AbstractHistogramTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new Predis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/HistogramWithPrefixTest.php
+++ b/tests/Test/Prometheus/Predis/HistogramWithPrefixTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Test\Prometheus\AbstractHistogramTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class HistogramWithPrefixTest extends AbstractHistogramTest
+{
+    public function configureAdapter(): void
+    {
+        $client = new Client([
+            'host'   => REDIS_HOST,
+            'prefix' => 'prefix:',
+        ]);
+
+        $client->connect();
+
+        $this->adapter = Predis::fromClient($client);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/SummaryTest.php
+++ b/tests/Test/Prometheus/Predis/SummaryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Test\Prometheus\AbstractSummaryTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class SummaryTest extends AbstractSummaryTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new Predis(['host' => REDIS_HOST]);
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/Predis/SummaryWithPrefixTest.php
+++ b/tests/Test/Prometheus/Predis/SummaryWithPrefixTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\Predis;
+
+use Predis\Client;
+use Prometheus\Storage\Predis;
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractSummaryTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
+ */
+class SummaryWithPrefixTest extends AbstractSummaryTest
+{
+    public function configureAdapter(): void
+    {
+        $client = new Client([
+            'host'   => REDIS_HOST,
+            'prefix' => 'prefix:',
+        ]);
+
+        $client->connect();
+
+        $this->adapter = Predis::fromClient($client);
+        $this->adapter->wipeStorage();
+    }
+}


### PR DESCRIPTION
Since predis library is a well-known alternative to phpredis, I've decided to add an extension to Redis storage adapter.

Some properties and methods were changed to protected in order to handle slight differences between these 2 libs.

Mostly additional params are passed as an array in phpredis and as single arguments in predis.