### PR TITLE
Backward compatiblity with older redis versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ ubuntu-latest ]
         php: [ 7.4, 8.0, 8.1, 8.2 ]
         dependency-version: [ prefer-lowest, prefer-stable ]
-        redis-version: [ 6 ]
+        redis-version: [ 5, 6, 7 ]
 
-    name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }} - ${{ matrix.redis-version }}
 
     env:
       # The hostname used to communicate with the Redis service container

--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -83,7 +83,7 @@ class CollectorRegistry implements RegistryInterface
      */
     public function getMetricFamilySamples(bool $sortMetrics = true): array
     {
-        return $this->storageAdapter->collect($sortMetrics);
+        return $this->storageAdapter->collect($sortMetrics);  /** @phpstan-ignore-line */
     }
 
     /**

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -123,6 +123,7 @@ class Redis implements Adapter
 
         $this->redis->eval(
             <<<LUA
+redis.replicate_commands()
 local cursor = "0"
 repeat 
     local results = redis.call('SCAN', cursor, 'MATCH', ARGV[1])

--- a/src/Prometheus/Storage/RedisNg.php
+++ b/src/Prometheus/Storage/RedisNg.php
@@ -123,6 +123,7 @@ class RedisNg implements Adapter
 
         $this->redis->eval(
             <<<LUA
+redis.replicate_commands()
 local cursor = "0"
 repeat 
     local results = redis.call('SCAN', cursor, 'MATCH', ARGV[1])

--- a/src/Prometheus/Storage/RedisNg.php
+++ b/src/Prometheus/Storage/RedisNg.php
@@ -475,7 +475,7 @@ LUA
      *
      * @return string
      */
-    private function removePrefixFromKey(string $key): string
+    private function removePrefixFromKey(string $key): string  /** @phpstan-ignore-line */
     {
         // @phpstan-ignore-next-line false positive, phpstan thinks getOptions returns int
         if ($this->redis->getOption(\Redis::OPT_PREFIX) === null) {

--- a/tests/Test/BlackBoxTest.php
+++ b/tests/Test/BlackBoxTest.php
@@ -45,7 +45,7 @@ class BlackBoxTest extends TestCase
 
         ];
 
-        Promise\settle($promises)->wait();
+        Promise\Utils::settle($promises)->wait();
         $end = microtime(true);
         echo "\ntime: " . ($end - $start) . "\n";
 
@@ -84,7 +84,7 @@ class BlackBoxTest extends TestCase
             $n += $increment;
         }
 
-        Promise\settle($promises)->wait();
+        Promise\Utils::settle($promises)->wait();
         $end = microtime(true);
         echo "\ntime: " . ($end - $start) . "\n";
 
@@ -124,7 +124,7 @@ class BlackBoxTest extends TestCase
             $this->client->getAsync('/examples/some_histogram.php?c=9&adapter=' . $this->adapter),
         ];
 
-        Promise\settle($promises)->wait();
+        Promise\Utils::settle($promises)->wait();
         $end = microtime(true);
         echo "\ntime: " . ($end - $start) . "\n";
 
@@ -168,7 +168,7 @@ EOF
             $this->client->getAsync('/examples/some_summary.php?c=10&adapter=' . $this->adapter),
         ];
 
-        Promise\settle($promises)->wait();
+        Promise\Utils::settle($promises)->wait();
         $end = microtime(true);
         echo "\ntime: " . ($end - $start) . "\n";
 


### PR DESCRIPTION
Hi there!

This PR adds backward compatiblity with redis versions lower 5. Wiping the redis storage did not work without the added command `redis.replicate_commands()`.

According to the redis documentation this command is deprecated in redis 7 but it still exists for backward compatiblity with older redis versions (see [here](https://redis.io/docs/interact/programmability/eval-intro/#replicating-commands-instead-of-scripts)).

We are using a redis 4 cluster and cannot upgrade it easily. So this MR helps us to get this component running without changing it externally.

Also others seem to have the same problem, ie #130 .