### PR TITLE
[RenderTextFormat] Allow value errors to be rendered as comments

### DIFF
--- a/tests/Test/Prometheus/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/RenderTextFormatTest.php
@@ -10,6 +10,8 @@ use Prometheus\MetricFamilySamples;
 use Prometheus\RenderTextFormat;
 use PHPUnit\Framework\TestCase;
 use Prometheus\Storage\InMemory;
+use Prometheus\Storage\Redis;
+use ValueError;
 
 class RenderTextFormatTest extends TestCase
 {
@@ -69,5 +71,59 @@ mynamespace_summary_count{label1="bob",label2="alice"} 1
 mynamespace_summary_sum{label1="bob",label2="alice"} 5
 
 TEXTPLAIN;
+    }
+
+    public function testValueErrorThrownWithInvalidSamples(): void
+    {
+        $namespace = 'foo';
+        $counter = 'bar';
+        $storage = new Redis(['host' => REDIS_HOST]);
+        $storage->wipeStorage();
+
+        $registry = new CollectorRegistry($storage, false);
+        $registry->registerCounter($namespace, $counter, 'counter-help-text', ['label1', 'label2'])
+            ->inc(['bob', 'alice']);
+
+        // Reload the registry with an updated counter config
+        $registry = new CollectorRegistry($storage, false);
+        $registry->registerCounter($namespace, $counter, 'counter-help-text', ['label1', 'label2', 'label3'])
+            ->inc(['bob', 'alice', 'eve']);
+
+        $this->expectException(ValueError::class);
+
+        $renderer = new RenderTextFormat();
+        $renderer->render($registry->getMetricFamilySamples());
+
+    }
+
+    public function testOutputWithInvalidSamplesSkipped(): void
+    {
+        $namespace = 'foo';
+        $counter = 'bar';
+        $storage = new Redis(['host' => REDIS_HOST]);
+        $storage->wipeStorage();
+
+        $registry = new CollectorRegistry($storage, false);
+        $registry->registerCounter($namespace, $counter, 'counter-help-text', ['label1', 'label2'])
+            ->inc(['bob', 'alice']);
+
+        // Reload the registry with an updated counter config
+        $registry = new CollectorRegistry($storage, false);
+        $registry->registerCounter($namespace, $counter, 'counter-help-text', ['label1', 'label2', 'label3'])
+            ->inc(['bob', 'alice', 'eve']);
+
+        $expectedOutput = '
+# HELP foo_bar counter-help-text
+# TYPE foo_bar counter
+foo_bar{label1="bob",label2="alice"} 1
+# Error: array_combine(): Argument #1 ($keys) and argument #2 ($values) must have the same number of elements
+#   Labels: ["label1","label2"]
+#   Values: ["bob","alice","eve"]
+';
+
+        $renderer = new RenderTextFormat();
+        $output = $renderer->render($registry->getMetricFamilySamples(), true);
+
+        self::assertSame(trim($expectedOutput), trim($output));
     }
 }

--- a/tests/Test/Prometheus/RenderTextFormatTest.php
+++ b/tests/Test/Prometheus/RenderTextFormatTest.php
@@ -93,7 +93,6 @@ TEXTPLAIN;
 
         $renderer = new RenderTextFormat();
         $renderer->render($registry->getMetricFamilySamples());
-
     }
 
     public function testOutputWithInvalidSamplesSkipped(): void


### PR DESCRIPTION
This PR addresses a specific scenario encountered with Redis and RedisNg storage, where samples with mismatching labels can be stored. For instance:
```
127.0.0.1:6379> hgetall PROMETHEUS_:counter:foo_bar
1) "[\"bob\",\"alice\",\"eve\"]"
2) "1"
3) "__meta"
4) "{\"name\":\"foo_bar\",\"help\":\"counter-help-text\",\"type\":\"counter\",\"labelNames\":[\"label1\",\"label2\"]}"
5) "[\"bob\",\"alice\"]"
6) "1"
```

In the above example, the counter metadata specifies `label1` and `label2` but it's possible to store samples with more or fewer labels, e.g.`["bob","alice","eve"]`. This could happen under different circumstances. For example, a new version of the code introduces `label3` for the counter. 

Depending on the setup, flushing the storage after the new code is out could be a valid way to avoid the problem. However, it becomes complex in environments with canary deployment where multiple versions of the code are required to run together. 

While there are ways to avoid the scenario, offering users the option to ignore errors for a limited number of metrics can be beneficial. It avoids the complete failure of the rendering operation in cases of minor inconsistencies. This PR does that.

Thanks for reviewing this! 🙏 
