### PR TITLE
Add PDO storage adapter. 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,11 @@ jobs:
       REDIS_HOST: redis
       # The default Redis port
       REDIS_PORT: 6379
+      # MySQL
+      DB_DATABASE: test
+      DB_USER: root
+      DB_PASSWORD: root
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -40,9 +45,23 @@ jobs:
 
       - name: Install dependencies
         run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
       - name: Start Redis
         uses: supercharge/redis-github-action@1.1.0
         with:
           redis-version: ${{ matrix.redis-version }}
-      - name: Execute tests
+
+      - name: Execute tests (PDO with Sqlite)
         run: vendor/bin/phpunit
+
+      - name: Start MySQL
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE;" -u$DB_USER -p$DB_PASSWORD
+
+      - name: Execute PDO tests with MySQL
+        env:
+          TEST_PDO_DSN: 'mysql:host=localhost;dbname=test'
+          TEST_PDO_USERNAME: 'root'
+          TEST_PDO_PASSWORD: 'root'
+        run: vendor/bin/phpunit tests/Test/Prometheus/PDO

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ $registry = new CollectorRegistry(new APC());
 ```
 (see the `README.APCng.md` file for more details)
 
+Using the PDO storage:
+```php
+$registry = new CollectorRegistry(new \PDO('mysql:host=localhost;dbname=prometheus', 'username', 'password'));
+ or
+$registry = new CollectorRegistry(new \PDO('sqlite::memory:'));
+```
 
 ### Advanced Usage
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "suggest": {
         "ext-redis": "Required if using Redis.",
         "ext-apc": "Required if using APCu.",
+        "ext-pdo": "Required if using PDO.",
         "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
         "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
     },

--- a/src/Prometheus/Storage/PDO.php
+++ b/src/Prometheus/Storage/PDO.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prometheus\Storage;
+
+use Prometheus\Counter;
+use Prometheus\MetricFamilySamples;
+use Prometheus\Summary;
+
+class PDO implements Adapter
+{
+    /**
+     * @var \PDO
+     */
+    protected $database;
+
+    /**
+     * @var string
+     */
+    protected $prefix;
+
+    /**
+     * @var array{0: int, 1: int}
+     */
+    protected $precision;
+
+    /**
+     * @param \PDO $database
+     *  PDO database connection.
+     * @param string $prefix
+     *  Database table prefix (default: "prometheus_").
+     * @param array{0: int, 1: int} $precision
+     *  Precision of the 'value' DECIMAL column in the database table (default: 16, 2).
+     */
+    public function __construct(\PDO $database, string $prefix = 'prometheus_', array $precision = [16, 2])
+    {
+        $this->database = $database;
+        $this->prefix = $prefix;
+        $this->precision = $precision;
+
+        $this->createTables();
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function collect(bool $sortMetrics = true): array
+    {
+        $metrics = $this->collectHistograms();
+        $metrics = array_merge($metrics, $this->collectGauges());
+        $metrics = array_merge($metrics, $this->collectCounters());
+        return array_merge($metrics, $this->collectSummaries());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function wipeStorage(): void
+    {
+        $this->database->query("DELETE FROM `{$this->prefix}_metadata`");
+        $this->database->query("DELETE FROM `{$this->prefix}_values`");
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    protected function collectHistograms(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    protected function collectSummaries(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    protected function collectCounters(): array
+    {
+        $result = [];
+
+        $meta_query = $this->database->prepare("SELECT name, metadata FROM `{$this->prefix}_metadata` WHERE type = :type");
+        $meta_query->execute([':type' => Counter::TYPE]);
+
+        while ($row = $meta_query->fetch(\PDO::FETCH_ASSOC)) {
+            $data = json_decode($row['metadata'], true);
+            $data['samples'] = [];
+
+            $values_query = $this->database->prepare("SELECT name, labels, value FROM `{$this->prefix}_values` WHERE name = :name AND type = :type");
+            $values_query->execute([
+                ':name' => $data['name'],
+                ':type' => Counter::TYPE,
+            ]);
+            while ($value_row = $values_query->fetch(\PDO::FETCH_ASSOC)) {
+                $data['samples'][] = [
+                    'name' => $value_row['name'],
+                    'labelNames' => [],
+                    'labelValues' => json_decode($value_row['labels'], true),
+                    'value' => $value_row['value'],
+                ];
+            }
+
+            $result[] = new MetricFamilySamples($data);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    protected function collectGauges(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param mixed[] $data
+     * @return void
+     */
+    public function updateHistogram(array $data): void
+    {
+        // TODO.
+    }
+
+    /**
+     * @param mixed[] $data
+     * @return void
+     */
+    public function updateSummary(array $data): void
+    {
+        // TODO do we update metadata at all? If metadata changes then the old labels might not be correct any more?
+        $metadata_sql = <<<SQL
+INSERT INTO  `{$this->prefix}_metadata`
+  VALUES(:name, :type, :metadata)
+  ON CONFLICT(name, type) DO UPDATE SET
+    metadata=excluded.metadata;
+SQL;
+
+        $statement = $this->database->prepare($metadata_sql);
+        $statement->execute([
+            ':name' => $data['name'],
+            ':type' => Summary::TYPE,
+            ':metadata' => $this->encodeMetadata($data),
+        ]);
+
+        if ($data['command'] === Adapter::COMMAND_SET) {
+            $values_sql = <<<SQL
+INSERT INTO  `{$this->prefix}_values`
+  VALUES(:name,:type,:hash,:labels,:value)
+  ON CONFLICT(name, type, labels_hash) DO UPDATE SET
+    `value` = excluded.value;
+SQL;
+        } else {
+            $values_sql = <<<SQL
+INSERT INTO  `{$this->prefix}_values`
+  VALUES(:name,:type,:hash,:labels,:value)
+  ON CONFLICT(name, type, labels_hash) DO UPDATE SET
+    `value` = `value` + excluded.value;
+SQL;
+        }
+
+        $statement = $this->database->prepare($values_sql);
+        $label_values = $this->encodeLabelValues($data);
+        $statement->execute([
+            ':name' => $data['name'],
+            ':type' => Summary::TYPE,
+            ':hash' => hash('sha256', $label_values),
+            ':labels' => $label_values,
+            ':value' => $data['value'],
+        ]);
+    }
+
+    /**
+     * @param mixed[] $data
+     */
+    public function updateGauge(array $data): void
+    {
+        // TODO.
+    }
+
+    /**
+     * @param mixed[] $data
+     */
+    public function updateCounter(array $data): void
+    {
+        // TODO do we update metadata at all? If metadata changes then the old labels might not be correct any more?
+        $metadata_sql = <<<SQL
+INSERT INTO  `{$this->prefix}_metadata`
+  VALUES(:name, :type, :metadata)
+  ON CONFLICT(name, type) DO UPDATE SET
+    metadata=excluded.metadata;
+SQL;
+
+        $statement = $this->database->prepare($metadata_sql);
+        $statement->execute([
+            ':name' => $data['name'],
+            ':type' => Counter::TYPE,
+            ':metadata' => $this->encodeMetadata($data),
+        ]);
+
+        if ($data['command'] === Adapter::COMMAND_SET) {
+            $values_sql = <<<SQL
+INSERT INTO  `{$this->prefix}_values`
+  VALUES(:name,:type,:hash,:labels,:value)
+  ON CONFLICT(name, type, labels_hash) DO UPDATE SET
+    `value` = excluded.value;
+SQL;
+        } else {
+            $values_sql = <<<SQL
+INSERT INTO  `{$this->prefix}_values`
+  VALUES(:name,:type,:hash,:labels,:value)
+  ON CONFLICT(name, type, labels_hash) DO UPDATE SET
+    `value` = `value` + excluded.value;
+SQL;
+        }
+
+        $statement = $this->database->prepare($values_sql);
+        $label_values = $this->encodeLabelValues($data);
+        $statement->execute([
+            ':name' => $data['name'],
+            ':type' => Counter::TYPE,
+            ':hash' => hash('sha256', $label_values),
+            ':labels' => $label_values,
+            ':value' => $data['value'],
+        ]);
+    }
+
+    protected function createTables(): void
+    {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS `{$this->prefix}_metadata` (
+    `name` varchar(255) NOT NULL,
+    `type` varchar(9) NOT NULL,
+    `metadata` text NOT NULL,
+    PRIMARY KEY (`name`, `type`)
+)
+SQL;
+        $this->database->query($sql);
+
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS `{$this->prefix}_values` (
+    `name` varchar(255) NOT NULL,
+    `type` varchar(9) NOT NULL,
+    `labels_hash` varchar(32) NOT NULL,
+    `labels` TEXT NOT NULL,
+    `value` DECIMAL({$this->precision[0]},{$this->precision[1]}) DEFAULT 0.0,
+    PRIMARY KEY (`name`, `type`, `labels_hash`)
+)
+SQL;
+        $this->database->query($sql);
+    }
+
+    /**
+     * @param mixed[] $data
+     * @return string
+     */
+    protected function encodeMetadata(array $data): string
+    {
+        unset($data['value'], $data['command'], $data['labelValues']);
+        $json = json_encode($data);
+        if (false === $json) {
+            throw new \RuntimeException(json_last_error_msg());
+        }
+        return $json;
+    }
+
+    /**
+     * @param mixed[] $data
+     * @return string
+     */
+    protected function encodeLabelValues(array $data): string
+    {
+        $json = json_encode($data['labelValues']);
+        if (false === $json) {
+            throw new \RuntimeException(json_last_error_msg());
+        }
+        return $json;
+    }
+}

--- a/src/Prometheus/Storage/PDO.php
+++ b/src/Prometheus/Storage/PDO.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prometheus\Storage;
 
 use Prometheus\Counter;
+use Prometheus\Math;
 use Prometheus\MetricFamilySamples;
 use Prometheus\Summary;
 
@@ -60,6 +61,7 @@ class PDO implements Adapter
     {
         $this->database->query("DELETE FROM `{$this->prefix}_metadata`");
         $this->database->query("DELETE FROM `{$this->prefix}_values`");
+        $this->database->query("DELETE FROM `{$this->prefix}_summaries`");
     }
 
     /**
@@ -75,7 +77,78 @@ class PDO implements Adapter
      */
     protected function collectSummaries(): array
     {
-        return [];
+        $math = new Math();
+        $result = [];
+
+        $meta_query = $this->database->prepare("SELECT name, metadata FROM `{$this->prefix}_metadata` WHERE type = :type");
+        $meta_query->execute([':type' => Summary::TYPE]);
+
+        while ($row = $meta_query->fetch(\PDO::FETCH_ASSOC)) {
+            $data = json_decode($row['metadata'], true);
+            $data['samples'] = [];
+
+            $values_query = $this->database->prepare("SELECT name, labels_hash, labels, value, time FROM `{$this->prefix}_summaries` WHERE name = :name AND type = :type");
+            $values_query->execute([
+                ':name' => $data['name'],
+                ':type' => Summary::TYPE,
+            ]);
+
+            $values = [];
+            while ($value_row = $values_query->fetch(\PDO::FETCH_ASSOC)) {
+                $values[$value_row['labels_hash']][] = $value_row;
+            }
+
+            foreach ($values as $labels_hash => $samples) {
+                $decoded_labels = json_decode(reset($samples)['labels'], true);
+
+                // Remove old data
+                $samples = array_filter($samples, function (array $value) use ($data): bool {
+                    return time() - $value['time'] <= $data['maxAgeSeconds'];
+                });
+                if (count($samples) === 0) {
+                    continue;
+                }
+
+                // Compute quantiles
+                usort($samples, function (array $value1, array $value2) {
+                    if ($value1['value'] === $value2['value']) {
+                        return 0;
+                    }
+                    return ($value1['value'] < $value2['value']) ? -1 : 1;
+                });
+
+                foreach ($data['quantiles'] as $quantile) {
+                    $data['samples'][] = [
+                        'name' => $data['name'],
+                        'labelNames' => ['quantile'],
+                        'labelValues' => array_merge($decoded_labels, [$quantile]),
+                        'value' => $math->quantile(array_column($samples, 'value'), $quantile),
+                    ];
+                }
+
+                // Add the count
+                $data['samples'][] = [
+                    'name' => $data['name'] . '_count',
+                    'labelNames' => [],
+                    'labelValues' => $decoded_labels,
+                    'value' => count($samples),
+                ];
+
+                // Add the sum
+                $data['samples'][] = [
+                    'name' => $data['name'] . '_sum',
+                    'labelNames' => [],
+                    'labelValues' => $decoded_labels,
+                    'value' => array_sum(array_column($samples, 'value')),
+                ];
+            }
+
+            if (count($data['samples']) > 0) {
+                $result[] = new MetricFamilySamples($data);
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -150,21 +223,10 @@ SQL;
             ':metadata' => $this->encodeMetadata($data),
         ]);
 
-        if ($data['command'] === Adapter::COMMAND_SET) {
             $values_sql = <<<SQL
-INSERT INTO  `{$this->prefix}_values`
-  VALUES(:name,:type,:hash,:labels,:value)
-  ON CONFLICT(name, type, labels_hash) DO UPDATE SET
-    `value` = excluded.value;
+INSERT INTO  `{$this->prefix}_summaries`(`name`, `type`, `labels_hash`, `labels`, `value`, `time`)
+  VALUES(:name,:type,:hash,:labels,:value,:time)
 SQL;
-        } else {
-            $values_sql = <<<SQL
-INSERT INTO  `{$this->prefix}_values`
-  VALUES(:name,:type,:hash,:labels,:value)
-  ON CONFLICT(name, type, labels_hash) DO UPDATE SET
-    `value` = `value` + excluded.value;
-SQL;
-        }
 
         $statement = $this->database->prepare($values_sql);
         $label_values = $this->encodeLabelValues($data);
@@ -174,6 +236,7 @@ SQL;
             ':hash' => hash('sha256', $label_values),
             ':labels' => $label_values,
             ':value' => $data['value'],
+            ':time' => time(),
         ]);
     }
 
@@ -207,14 +270,14 @@ SQL;
 
         if ($data['command'] === Adapter::COMMAND_SET) {
             $values_sql = <<<SQL
-INSERT INTO  `{$this->prefix}_values`
+INSERT INTO  `{$this->prefix}_values`(`name`, `type`, `labels_hash`, `labels`, `value`)
   VALUES(:name,:type,:hash,:labels,:value)
   ON CONFLICT(name, type, labels_hash) DO UPDATE SET
     `value` = excluded.value;
 SQL;
         } else {
             $values_sql = <<<SQL
-INSERT INTO  `{$this->prefix}_values`
+INSERT INTO  `{$this->prefix}_values`(`name`, `type`, `labels_hash`, `labels`, `value`)
   VALUES(:name,:type,:hash,:labels,:value)
   ON CONFLICT(name, type, labels_hash) DO UPDATE SET
     `value` = `value` + excluded.value;
@@ -253,6 +316,19 @@ CREATE TABLE IF NOT EXISTS `{$this->prefix}_values` (
     `value` DECIMAL({$this->precision[0]},{$this->precision[1]}) DEFAULT 0.0,
     PRIMARY KEY (`name`, `type`, `labels_hash`)
 )
+SQL;
+        $this->database->query($sql);
+
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS `{$this->prefix}_summaries` (
+    `name` varchar(255) NOT NULL,
+    `type` varchar(9) NOT NULL,
+    `labels_hash` varchar(32) NOT NULL,
+    `labels` TEXT NOT NULL,
+    `value` DECIMAL({$this->precision[0]},{$this->precision[1]}) DEFAULT 0.0,
+    `time` timestamp NOT NULL
+); 
+CREATE INDEX `name_type` ON `{$this->prefix}_summaries`(`name`, `type`);
 SQL;
         $this->database->query($sql);
     }

--- a/tests/Test/Prometheus/PDO/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/PDO/CollectorRegistryTest.php
@@ -9,9 +9,25 @@ use Test\Prometheus\AbstractCollectorRegistryTest;
 
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
+    /**
+     * @var \PDO|null
+     */
+    private $pdo;
+
     public function configureAdapter(): void
     {
-        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->pdo = new \PDO('sqlite::memory:');
+        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
+        $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->adapter->deleteTables(); /** @phpstan-ignore-line */
+        $this->adapter = null; /** @phpstan-ignore-line */
+        $this->pdo = null;
     }
 }

--- a/tests/Test/Prometheus/PDO/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/PDO/CollectorRegistryTest.php
@@ -9,6 +9,8 @@ use Test\Prometheus\AbstractCollectorRegistryTest;
 
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
+    use PdoCredentialsTrait;
+
     /**
      * @var \PDO|null
      */
@@ -16,8 +18,7 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
 
     public function configureAdapter(): void
     {
-        $this->pdo = new \PDO('sqlite::memory:');
-        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $this->pdo = new \PDO($this->getDsn(), $this->getUsername(), $this->getPassword());
         $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
         $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();

--- a/tests/Test/Prometheus/PDO/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/PDO/CollectorRegistryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\PDO;
+
+use Prometheus\Storage\PDO;
+use Test\Prometheus\AbstractCollectorRegistryTest;
+
+class CollectorRegistryTest extends AbstractCollectorRegistryTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/PDO/CounterTest.php
+++ b/tests/Test/Prometheus/PDO/CounterTest.php
@@ -12,9 +12,25 @@ use Test\Prometheus\AbstractCounterTest;
  */
 class CounterTest extends AbstractCounterTest
 {
+    /**
+     * @var \PDO|null
+     */
+    private $pdo;
+
     public function configureAdapter(): void
     {
-        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->pdo = new \PDO('sqlite::memory:');
+        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
+        $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->adapter->deleteTables(); /** @phpstan-ignore-line */
+        $this->adapter = null; /** @phpstan-ignore-line */
+        $this->pdo = null;
     }
 }

--- a/tests/Test/Prometheus/PDO/CounterTest.php
+++ b/tests/Test/Prometheus/PDO/CounterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\PDO;
+
+use Prometheus\Storage\PDO;
+use Test\Prometheus\AbstractCounterTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class CounterTest extends AbstractCounterTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/PDO/CounterTest.php
+++ b/tests/Test/Prometheus/PDO/CounterTest.php
@@ -12,6 +12,8 @@ use Test\Prometheus\AbstractCounterTest;
  */
 class CounterTest extends AbstractCounterTest
 {
+    use PdoCredentialsTrait;
+
     /**
      * @var \PDO|null
      */
@@ -19,8 +21,7 @@ class CounterTest extends AbstractCounterTest
 
     public function configureAdapter(): void
     {
-        $this->pdo = new \PDO('sqlite::memory:');
-        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $this->pdo = new \PDO($this->getDsn(), $this->getUsername(), $this->getPassword());
         $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
         $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();

--- a/tests/Test/Prometheus/PDO/GaugeTest.php
+++ b/tests/Test/Prometheus/PDO/GaugeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\PDO;
+
+use Prometheus\Storage\PDO;
+use Test\Prometheus\AbstractGaugeTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class GaugeTest extends AbstractGaugeTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/PDO/GaugeTest.php
+++ b/tests/Test/Prometheus/PDO/GaugeTest.php
@@ -12,6 +12,8 @@ use Test\Prometheus\AbstractGaugeTest;
  */
 class GaugeTest extends AbstractGaugeTest
 {
+    use PdoCredentialsTrait;
+
     /**
      * @var \PDO|null
      */
@@ -19,8 +21,7 @@ class GaugeTest extends AbstractGaugeTest
 
     public function configureAdapter(): void
     {
-        $this->pdo = new \PDO('sqlite::memory:');
-        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $this->pdo = new \PDO($this->getDsn(), $this->getUsername(), $this->getPassword());
         $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
         $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();

--- a/tests/Test/Prometheus/PDO/GaugeTest.php
+++ b/tests/Test/Prometheus/PDO/GaugeTest.php
@@ -12,9 +12,25 @@ use Test\Prometheus\AbstractGaugeTest;
  */
 class GaugeTest extends AbstractGaugeTest
 {
+    /**
+     * @var \PDO|null
+     */
+    private $pdo;
+
     public function configureAdapter(): void
     {
-        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->pdo = new \PDO('sqlite::memory:');
+        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
+        $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->adapter->deleteTables(); /** @phpstan-ignore-line */
+        $this->adapter = null; /** @phpstan-ignore-line */
+        $this->pdo = null;
     }
 }

--- a/tests/Test/Prometheus/PDO/HistogramTest.php
+++ b/tests/Test/Prometheus/PDO/HistogramTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\PDO;
+
+use Prometheus\Storage\PDO;
+use Test\Prometheus\AbstractHistogramTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class HistogramTest extends AbstractHistogramTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/PDO/HistogramTest.php
+++ b/tests/Test/Prometheus/PDO/HistogramTest.php
@@ -12,9 +12,25 @@ use Test\Prometheus\AbstractHistogramTest;
  */
 class HistogramTest extends AbstractHistogramTest
 {
+    /**
+     * @var \PDO|null
+     */
+    private $pdo;
+
     public function configureAdapter(): void
     {
-        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->pdo = new \PDO('sqlite::memory:');
+        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
+        $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->adapter->deleteTables(); /** @phpstan-ignore-line */
+        $this->adapter = null; /** @phpstan-ignore-line */
+        $this->pdo = null;
     }
 }

--- a/tests/Test/Prometheus/PDO/HistogramTest.php
+++ b/tests/Test/Prometheus/PDO/HistogramTest.php
@@ -12,6 +12,8 @@ use Test\Prometheus\AbstractHistogramTest;
  */
 class HistogramTest extends AbstractHistogramTest
 {
+    use PdoCredentialsTrait;
+
     /**
      * @var \PDO|null
      */
@@ -19,8 +21,7 @@ class HistogramTest extends AbstractHistogramTest
 
     public function configureAdapter(): void
     {
-        $this->pdo = new \PDO('sqlite::memory:');
-        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $this->pdo = new \PDO($this->getDsn(), $this->getUsername(), $this->getPassword());
         $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
         $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();

--- a/tests/Test/Prometheus/PDO/PdoCredentialsTrait.php
+++ b/tests/Test/Prometheus/PDO/PdoCredentialsTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\PDO;
+
+trait PdoCredentialsTrait
+{
+    private function getEnvironmentWithDefault(string $name, ?string $default = null): ?string
+    {
+        $env = getenv($name);
+        return $env === false ? $default : $env;
+    }
+
+    private function getDsn(): string
+    {
+        return $this->getEnvironmentWithDefault('TEST_PDO_DSN', 'sqlite::memory:');
+    }
+
+    private function getUsername(): ?string
+    {
+        return $this->getEnvironmentWithDefault('TEST_PDO_USERNAME');
+    }
+
+    private function getPassword(): ?string
+    {
+        return $this->getEnvironmentWithDefault('TEST_PDO_PASSWORD');
+    }
+}

--- a/tests/Test/Prometheus/PDO/PdoCredentialsTrait.php
+++ b/tests/Test/Prometheus/PDO/PdoCredentialsTrait.php
@@ -14,7 +14,7 @@ trait PdoCredentialsTrait
 
     private function getDsn(): string
     {
-        return $this->getEnvironmentWithDefault('TEST_PDO_DSN', 'sqlite::memory:');
+        return $this->getEnvironmentWithDefault('TEST_PDO_DSN', 'sqlite::memory:'); /** @phpstan-ignore-line */
     }
 
     private function getUsername(): ?string

--- a/tests/Test/Prometheus/PDO/SummaryTest.php
+++ b/tests/Test/Prometheus/PDO/SummaryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Prometheus\PDO;
+
+use Prometheus\Storage\PDO;
+use Test\Prometheus\AbstractSummaryTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class SummaryTest extends AbstractSummaryTest
+{
+    public function configureAdapter(): void
+    {
+        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->adapter->wipeStorage();
+    }
+}

--- a/tests/Test/Prometheus/PDO/SummaryTest.php
+++ b/tests/Test/Prometheus/PDO/SummaryTest.php
@@ -12,9 +12,25 @@ use Test\Prometheus\AbstractSummaryTest;
  */
 class SummaryTest extends AbstractSummaryTest
 {
+    /**
+     * @var \PDO|null
+     */
+    private $pdo;
+
     public function configureAdapter(): void
     {
-        $this->adapter = new PDO(new \PDO('sqlite::memory:'));
+        $this->pdo = new \PDO('sqlite::memory:');
+        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
+        $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->adapter->deleteTables(); /** @phpstan-ignore-line */
+        $this->adapter = null; /** @phpstan-ignore-line */
+        $this->pdo = null;
     }
 }

--- a/tests/Test/Prometheus/PDO/SummaryTest.php
+++ b/tests/Test/Prometheus/PDO/SummaryTest.php
@@ -12,6 +12,8 @@ use Test\Prometheus\AbstractSummaryTest;
  */
 class SummaryTest extends AbstractSummaryTest
 {
+    use PdoCredentialsTrait;
+
     /**
      * @var \PDO|null
      */
@@ -19,8 +21,7 @@ class SummaryTest extends AbstractSummaryTest
 
     public function configureAdapter(): void
     {
-        $this->pdo = new \PDO('sqlite::memory:');
-        //$this->pdo = new \PDO('mysql:host=db;dbname=db', 'db', 'db');
+        $this->pdo = new \PDO($this->getDsn(), $this->getUsername(), $this->getPassword());
         $prefix = 'test' . substr(hash('sha256', uniqid()), 0, 6) . '_';
         $this->adapter = new PDO($this->pdo, $prefix);
         $this->adapter->wipeStorage();


### PR DESCRIPTION
We have a use case where we need to use a database as a storage backend - yes, we are aware that this won't be as performant as Redis or APC. Unfortunately we are not able to use either of those. And we are expecting a limited number of metrics. 

The provided adapter passes the standard test suite with both SQLite and MySQL. The latter obviously won't run on GH actions, but I am happy to add that configuration if the maintainers will show preparedness to merge this. 