### PR TITLE
Ensure that label values are strings in APCNg adapter

### DIFF
--- a/src/Prometheus/Storage/APCng.php
+++ b/src/Prometheus/Storage/APCng.php
@@ -254,7 +254,7 @@ class APCng implements Adapter
                 $data['name'],
                 $label,
                 'label'
-            ]), isset($data['labelValues']) ? $data['labelValues'][$seq] : ''); // may not need the isset check
+            ]), isset($data['labelValues']) ? (string)$data['labelValues'][$seq] : ''); // may not need the isset check
         }
     }
 
@@ -860,7 +860,7 @@ class APCng implements Adapter
      */
     private function encodeLabelValues(array $values): string
     {
-        $json = json_encode($values);
+        $json = json_encode(array_map("strval", $values));
         if (false === $json) {
             throw new RuntimeException(json_last_error_msg());
         }

--- a/tests/Test/Prometheus/Storage/APCngTest.php
+++ b/tests/Test/Prometheus/Storage/APCngTest.php
@@ -56,13 +56,10 @@ class APCngTest extends TestCase
             'int_label_values',
             'test int label values',
             ['int_label'],
-        )->inc([3]);
+        )->incBy(3, [3]);
 
-        $jsonLabels = json_encode(["3"]);
-        $encodedLabels = base64_encode($jsonLabels);
-
-        $counter = apcu_fetch("prom:counter:ns_int_label_values:{$encodedLabels}:value");
-        $this->assertSame(1000, $counter);
+        $counter = apcu_fetch("prom:counter:ns_int_label_values:WyIzIl0=:value");
+        self::assertSame(3000, $counter);
     }
 
     /**

--- a/tests/Test/Prometheus/Storage/APCngTest.php
+++ b/tests/Test/Prometheus/Storage/APCngTest.php
@@ -45,6 +45,29 @@ class APCngTest extends TestCase
     /**
      * @test
      */
+    public function nonStringLabelValuesAreCastToStrings(): void
+    {
+        apcu_clear_cache();
+
+        $adapter = new APCng();
+        $registry = new CollectorRegistry($adapter);
+        $registry->getOrRegisterCounter(
+            'ns',
+            'int_label_values',
+            'test int label values',
+            ['int_label'],
+        )->inc([3]);
+
+        $jsonLabels = json_encode(["3"]);
+        $encodedLabels = base64_encode($jsonLabels);
+
+        $counter = apcu_fetch("prom:counter:ns_int_label_values:{$encodedLabels}:value");
+        $this->assertSame(1000, $counter);
+    }
+
+    /**
+     * @test
+     */
     public function itShouldUseConfiguredPrefix(): void
     {
         $apc = new APCng('custom_prefix');


### PR DESCRIPTION
APCNg is crashing if the label value provided wasn't a string, but something that can be coerced to string (such as int). Other adaptors work properly in this situation.

The problem occurs in two different places:
- when a metric is emitted, the `storeLabelKeys()` calls into `addItemToKey()` which has its second parameter type hinted as a `string` and throws a type error if anything else is passed. This results in partially stored state;
- when trying to scrape metrics with partially stored state, the `APCng::collect()` will try to build all the permutations and expect all the key-value pairs for labels to exist, but numeric label values aren't persisted and so it will cause the `Undefined array key` error as reported in #154;

This change ensures that label values are cast to the `string` type before encoding them and using as APC keys.

An alternative that can be considered is adding a label check / cast at the individual collector layers. Given other adaptors work properly – this solution seemed fitting. Introducing a check into the collectors layer will cause a breaking change, so probably isn't the best option.

Fixes #154 