### PR TITLE
Redis - Metrics collection should not write anything

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -536,7 +536,11 @@ LUA
                 }
 
                 if (count($samples) === 0) {
-                    $this->redis->del($valueKey);
+                    try {
+                        $this->redis->del($valueKey);
+                    } catch (\RedisException $e) {
+                        // ignore if we can't delete the key
+                    }
                     continue;
                 }
 
@@ -571,7 +575,11 @@ LUA
             if (count($data['samples']) > 0) {
                 $summaries[] = $data;
             } else {
-                $this->redis->del($metaKey);
+                try {
+                    $this->redis->del($metaKey);
+                } catch (\RedisException $e) {
+                    // ignore if we can't delete the key
+                }
             }
         }
         return $summaries;


### PR DESCRIPTION
We are using the Redis master node for writing and slave node(s) for reading - if we try to collect metrics `Redis::collectSummaries()` sometimes tries to delete some keys from storage, which is impossible on the READ ONLY node.