### PR TITLE
Redis ACL AUTH two argument supporting.

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -28,6 +28,7 @@ class Redis implements Adapter
         'read_timeout' => '10',
         'persistent_connections' => false,
         'password' => null,
+        'user' => null,
     ];
 
     /**
@@ -196,8 +197,18 @@ LUA
 
         $this->connectToServer();
 
-        if ($this->options['password'] !== null) {
-            $this->redis->auth($this->options['password']);
+        $authParams = [];
+
+        if (isset($this->options['user'])) {
+            $authParams[] = $this->options['user'];
+        }
+
+        if (isset($this->options['password'])) {
+            $authParams[] = $this->options['password'];
+        }
+
+        if (!empty($authParams)) {
+            $this->redis->auth($authParams);
         }
 
         if (isset($this->options['database'])) {

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -196,7 +196,6 @@ LUA
         }
 
         $this->connectToServer();
-
         $authParams = [];
 
         if (isset($this->options['user'])) {

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -206,7 +206,7 @@ LUA
             $authParams[] = $this->options['password'];
         }
 
-        if (!empty($authParams)) {
+        if ($authParams !== []) {
             $this->redis->auth($authParams);
         }
 

--- a/src/Prometheus/Storage/RedisNg.php
+++ b/src/Prometheus/Storage/RedisNg.php
@@ -28,6 +28,7 @@ class RedisNg implements Adapter
         'read_timeout' => '10',
         'persistent_connections' => false,
         'password' => null,
+        'user' => null,
     ];
 
     /**
@@ -195,9 +196,18 @@ LUA
         }
 
         $this->connectToServer();
+        $authParams = [];
 
-        if ($this->options['password'] !== null) {
-            $this->redis->auth($this->options['password']);
+        if (isset($this->options['user'])) {
+            $authParams[] = $this->options['user'];
+        }
+
+        if (isset($this->options['password'])) {
+            $authParams[] = $this->options['password'];
+        }
+
+        if (!empty($authParams)) {
+            $this->redis->auth($authParams);
         }
 
         if (isset($this->options['database'])) {

--- a/src/Prometheus/Storage/RedisNg.php
+++ b/src/Prometheus/Storage/RedisNg.php
@@ -206,7 +206,7 @@ LUA
             $authParams[] = $this->options['password'];
         }
 
-        if (!empty($authParams)) {
+        if ($authParams !== []) {
             $this->redis->auth($authParams);
         }
 


### PR DESCRIPTION
From 
https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/

since version 6, redis supports authorization using two arguments - a user and a password, the current version of the library uses only a password