### PR TITLE
Ignore phpstan argument.type lint in test

### DIFF
--- a/tests/Test/Prometheus/Storage/APCngTest.php
+++ b/tests/Test/Prometheus/Storage/APCngTest.php
@@ -56,7 +56,7 @@ class APCngTest extends TestCase
             'int_label_values',
             'test int label values',
             ['int_label'],
-        )->incBy(3, [3]);
+        )->incBy(3, [3]); // @phpstan-ignore argument.type
 
         $counter = apcu_fetch("prom:counter:ns_int_label_values:WyIzIl0=:value");
         self::assertSame(3000, $counter);


### PR DESCRIPTION
PHPStan tests fail because one test purposefully uses wrong type of input. This pull request will tell PHPStan to ignore "argument.type" lint for this one line.