### PR TITLE
Correctly handle empty username for Redis/RedisNg AUTH

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -198,7 +198,7 @@ LUA
         $this->connectToServer();
         $authParams = [];
 
-        if (isset($this->options['user'])) {
+        if (isset($this->options['user']) && $this->options['user'] !== '') {
             $authParams[] = $this->options['user'];
         }
 

--- a/src/Prometheus/Storage/RedisNg.php
+++ b/src/Prometheus/Storage/RedisNg.php
@@ -198,7 +198,7 @@ LUA
         $this->connectToServer();
         $authParams = [];
 
-        if (isset($this->options['user'])) {
+        if (isset($this->options['user']) && $this->options['user'] !== '') {
             $authParams[] = $this->options['user'];
         }
 


### PR DESCRIPTION
Hey! Bug issue reported here #171 

This PR simply checks if the username is empty which is quite common, and if so exclude it from `auth` call.