### PR TITLE
create index if not exist to prevent duplicate error

### DIFF
--- a/src/Prometheus/Storage/PDO.php
+++ b/src/Prometheus/Storage/PDO.php
@@ -641,7 +641,7 @@ CREATE TABLE IF NOT EXISTS `{$this->prefix}_summaries` (
     `time` {$timestamp_type} NOT NULL
 );
 SQL;
-                $sqlIndex = "CREATE INDEX `name` ON `{$this->prefix}_summaries`(`name`);";
+                $sqlIndex = "CREATE INDEX IF NOT EXISTS `name` ON `{$this->prefix}_summaries`(`name`);";
                 break;
 
             case 'mysql':
@@ -667,7 +667,7 @@ CREATE TABLE IF NOT EXISTS "{$this->prefix}_summaries" (
     "time" {$timestamp_type} NOT NULL
 );
 SQL;
-                $sqlIndex = "CREATE INDEX \"name\" ON \"{$this->prefix}_summaries\" (\"name\");";
+                $sqlIndex = "CREATE INDEX IF NOT EXISTS \"name\" ON \"{$this->prefix}_summaries\" (\"name\");";
                 break;
         }
 


### PR DESCRIPTION
When using the PDO method of storage for data, several tables are created if they do not already exist, and for pgsql and sqlite users, a 'name' index is also created, but no check is done to ensure that the index does not already exist; this can result in an error such as the following when called from a singleton:
`SQLSTATE[42P07]: Duplicate table: 7 ERROR: relation "name" already exists`

In this particular use-case, each /api request to the local application triggers a recording of metrics to the database to be eventually scraped by Prometheus using `CollectorRegistry` singleton, which requires a `PDO` instance also in a singleton.(`PDO` implements `Adapter`, which is a required argument for the `CollectorRegistry` constructor.)
The now stored metrics must persist between api calls and persist between singletons, so that Prometheus can scrape it all at once, but each individual singleton as a result of these /api calls tries to create the 'name' index, causing the error, since the very first singleton already created these tables/index to store the metrics for future singles to also write to until Prometheus scrapes it, and flushes the data using PDO's wipeStorage().

This small branch aims to fix that by adding a check to both pgsql and sqlite cases.