### PR TITLE
Changed the parent class for MetricNotFoundException to improve the exception hierarchy

### DIFF
--- a/src/Prometheus/Exception/MetricNotFoundException.php
+++ b/src/Prometheus/Exception/MetricNotFoundException.php
@@ -2,11 +2,11 @@
 
 namespace Prometheus\Exception;
 
-use Exception;
+use RuntimeException;
 
 /**
  * Exception thrown if a metric can't be found in the CollectorRegistry.
  */
-class MetricNotFoundException extends Exception
+class MetricNotFoundException extends RuntimeException
 {
 }


### PR DESCRIPTION
We are working on refining the exception hierarchy within our campaign.

RuntimeException is a more accurate choice for this exception from my perspective.

I suggest a small change if it doesn't cause any issues.