### PR TITLE
Drop support for EOL PHP versions, require PHP 8.2+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
         redis-version: [ 5, 6, 7, 8 ]
 
     name: P${{ matrix.php }} - Redis ${{ matrix.redis-version }}

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ composer require promphp/prometheus_push_gateway_php
 
 ### Dependencies
 
-* PHP ^7.2 | ^8.0
+* PHP ^8.2 (only [supported PHP versions](https://www.php.net/supported-versions.php) are supported)
 * PHP Redis extension
 * PHP APCu extension
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "lkaemmerling/prometheus_client_php": "*"
     },
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.2",
         "ext-json": "*"
     },
     "require-dev": {
@@ -33,7 +33,7 @@
         "ext-apc": "Required if using APCu.",
         "ext-pdo": "Required if using PDO.",
         "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
-        "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
+        "symfony/polyfill-apcu": "Required if you use APCu."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Bump minimum PHP version from `^7.4|^8.0` to `^8.2`
- Remove PHP 8.1 from CI test matrix
- PHP 7.4, 8.0, and 8.1 have all reached end of life

## Impact
Users on PHP < 8.2 will need to upgrade before updating to this version.