### PR TITLE
fix: handle null Predis set members

### DIFF
--- a/src/Prometheus/Storage/RedisClients/Predis.php
+++ b/src/Prometheus/Storage/RedisClients/Predis.php
@@ -83,7 +83,8 @@ class Predis implements RedisClient
 
     public function sMembers(string $key): array
     {
-        return $this->client->smembers($key);
+        /** @phpstan-ignore-next-line Predis can return null at runtime despite its array return type. */
+        return $this->client->smembers($key) ?? [];
     }
 
     public function hGetAll(string $key): array|false

--- a/tests/Test/Prometheus/Storage/PredisTest.php
+++ b/tests/Test/Prometheus/Storage/PredisTest.php
@@ -58,4 +58,24 @@ class PredisTest extends TestCase
             self::equalTo(['not a prometheus metric key'])
         );
     }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnAnEmptyArrayWhenSMembersReturnsNull(): void
+    {
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['smembers'])
+            ->getMock();
+
+        $client->expects(self::once())
+            ->method('smembers')
+            ->with('missing-key')
+            ->willReturn(null);
+
+        $predis = new \Prometheus\Storage\RedisClients\Predis($client);
+
+        self::assertSame([], $predis->sMembers('missing-key'));
+    }
 }


### PR DESCRIPTION
## Summary
- Normalize null Predis SMEMBERS responses to an empty array
- Predis can return null from SMEMBERS at runtime despite its declared array return type
- Add a regression test for null SMEMBERS results

It actually happened even though contract does not allow it.

<img width="1252" height="601" alt="image" src="https://github.com/user-attachments/assets/17ff26c6-2aa2-4733-ad11-165a9bcdb47c" />
