### PR TITLE
fix: stabilize blackbox tests

### DIFF
--- a/php-fpm/www.conf
+++ b/php-fpm/www.conf
@@ -1,7 +1,7 @@
 [www]
 user = www-data
 group = www-data
-listen = 127.0.0.1:9000
+listen = 9000
 pm = static
 pm.max_children = 20
 access.format = "%R %p [%t] \"%m %r\" %s %{micro}d %C %M %l"

--- a/src/Prometheus/Storage/APCng.php
+++ b/src/Prometheus/Storage/APCng.php
@@ -148,17 +148,17 @@ class APCng implements Adapter
         // Check if sample counter for this timestamp already exists, so we can deterministically
         // store observations+counts, one key per second
         // Atomic increment of the observation counter, or initialize if new
-        $sampleCount = apcu_fetch($sampleCountKey);
-
-        if ($sampleCount === false) {
-            $sampleCount = 0;
-            apcu_add($sampleCountKey, $sampleCount, $data['maxAgeSeconds']);
+        if (apcu_fetch($sampleCountKey) === false) {
+            apcu_add($sampleCountKey, 0, $data['maxAgeSeconds']);
         }
 
-        $this->doIncrementKeyWithValue($sampleCountKey, 1);
+        $sampleCount = apcu_inc($sampleCountKey);
+        if ($sampleCount === false) { /** @phpstan-ignore-line */
+            throw new RuntimeException('Failed to increment summary sample counter');
+        }
 
         // We now have a deterministic keyname for this observation; let's save the observed value
-        $sampleKey = $sampleKeyPrefix . '.' . $sampleCount;
+        $sampleKey = $sampleKeyPrefix . '.' . ($sampleCount - 1);
         apcu_add($sampleKey, $data['value'], $data['maxAgeSeconds']);
     }
 


### PR DESCRIPTION
## Summary
- Configure PHP-FPM to listen on port 9000 on all container interfaces
- Fix BlackBox nginx 502 responses caused by nginx connecting to php-fpm:9000 while FPM only listened on loopback inside its own container
- Reserve APCng summary observation indexes with the atomic apcu_inc() return value to avoid losing concurrent observations

## Verification
- docker compose up -d --build
- docker compose run --rm phpunit env ADAPTER=apc vendor/bin/phpunit --filter gaugesShouldBeOverwritten tests/Test/BlackBoxTest.php
- docker compose run --rm phpunit env ADAPTER=apc vendor/bin/phpunit tests/Test/BlackBoxTest.php
- docker compose run --rm phpunit env ADAPTER=apcng vendor/bin/phpunit tests/Test/BlackBoxTest.php